### PR TITLE
Exclude org.wildfly.swarm:bootstrap to avoid duplicated classes

### DIFF
--- a/guvnor-ala/guvnor-ala-distribution/pom.xml
+++ b/guvnor-ala/guvnor-ala-distribution/pom.xml
@@ -49,6 +49,10 @@
       <artifactId>container</artifactId>
       <exclusions>
         <exclusion>
+          <groupId>org.wildfly.swarm</groupId>
+          <artifactId>bootstrap</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.ow2.asm</groupId>
           <artifactId>asm-all</artifactId>
         </exclusion>


### PR DESCRIPTION
The dependency tree of the guvnor-ala-distribution needs a serious
review. We should be able to get rid of the Swarm deps altogether
(and use the plugin config) as they just pollute the dep. tree.

Should be merged together with https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/417