### PR TITLE
GUVNOR-2933: Guvnor ALA integration

### DIFF
--- a/guvnor-ala/guvnor-ala-spi/src/main/java/org/guvnor/ala/pipeline/execution/PipelineExecutor.java
+++ b/guvnor-ala/guvnor-ala-spi/src/main/java/org/guvnor/ala/pipeline/execution/PipelineExecutor.java
@@ -100,8 +100,6 @@ public class PipelineExecutor {
                     }
 
                     propagateEvent( new AfterStageExecutionEvent( context.getPipeline(), stage ), eventListeners );
-
-                    continuePipeline( context, eventListeners );
                 } );
             } catch ( final Throwable t ) {
                 t.printStackTrace();
@@ -110,13 +108,10 @@ public class PipelineExecutor {
                 propagateEvent( new OnErrorPipelineExecutionEvent( context.getPipeline(), stage, exception ), eventListeners );
                 throw exception;
             }
-            return;
         }
-        if ( context.isFinished() ) {
-            final Object output = pollOutput( context );
-            while ( context.hasCallbacks() ) {
-                context.applyCallbackAndPop( output );
-            }
+        final Object output = pollOutput( context );
+        while ( context.hasCallbacks( ) ) {
+            context.applyCallbackAndPop( output );
         }
     }
 


### PR DESCRIPTION
    - Removes unnecessary recursive invocation in the PipelineExecutor that was doing nothing.
      See that the pipeline execution loop is based on the !context.isFinished so recursive invocation is not neccesary.