### PR TITLE
GUVNOR-2976: Guided Decision Table Graph: Save operation saves changes just to selected graph

### DIFF
--- a/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/model/Metadata.java
+++ b/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/model/Metadata.java
@@ -40,8 +40,8 @@ public class Metadata {
     private String lastContributor;
     private String creator;
     //git -> basic file attrs
-    private Date   lastModified;
-    private Date   dateCreated;
+    private Date lastModified;
+    private Date dateCreated;
 
     //pure dcore
     private String subject;
@@ -51,9 +51,9 @@ public class Metadata {
     private String description;
 
     //not dcore
-    private List<String>           tags = new ArrayList<String>();
+    private List<String> tags = new ArrayList<String>();
     private List<DiscussionRecord> discussion = new ArrayList<DiscussionRecord>();
-    private List<VersionRecord>    version    = new ArrayList<VersionRecord>();
+    private List<VersionRecord> version = new ArrayList<VersionRecord>();
 
     private boolean generated;
 
@@ -61,23 +61,23 @@ public class Metadata {
 
     }
 
-    public Metadata( final Path path,
-                     final Path realPath,
-                     final String checkinComment,
-                     final String lastContributor,
-                     final String creator,
-                     final Date lastModified,
-                     final Date dateCreated,
-                     final String subject,
-                     final String type,
-                     final String externalRelation,
-                     final String externalSource,
-                     final String description,
-                     final List<String> tags,
-                     final List<DiscussionRecord> discussion,
-                     final List<VersionRecord> version,
-                     final LockInfo lockInfo,
-                     final boolean generated ) {
+    public Metadata(final Path path,
+                    final Path realPath,
+                    final String checkinComment,
+                    final String lastContributor,
+                    final String creator,
+                    final Date lastModified,
+                    final Date dateCreated,
+                    final String subject,
+                    final String type,
+                    final String externalRelation,
+                    final String externalSource,
+                    final String description,
+                    final List<String> tags,
+                    final List<DiscussionRecord> discussion,
+                    final List<VersionRecord> version,
+                    final LockInfo lockInfo,
+                    final boolean generated) {
         this.path = path;
         this.realPath = realPath;
         this.checkinComment = checkinComment;
@@ -100,7 +100,7 @@ public class Metadata {
     public Path getPath() {
         return path;
     }
-    
+
     public Path getRealPath() {
         return realPath;
     }
@@ -156,7 +156,7 @@ public class Metadata {
     public List<VersionRecord> getVersion() {
         return version;
     }
-    
+
     public LockInfo getLockInfo() {
         return lockInfo;
     }
@@ -165,106 +165,106 @@ public class Metadata {
         return generated;
     }
 
-    public void setLockInfo( LockInfo lockInfo ) {
+    public void setLockInfo(LockInfo lockInfo) {
         this.lockInfo = lockInfo;
     }
 
-    public void setSubject( final String subject ) {
+    public void setSubject(final String subject) {
         this.subject = subject;
     }
 
-    public void setType( final String type ) {
+    public void setType(final String type) {
         this.type = type;
     }
 
-    public void setExternalRelation( final String externalRelation ) {
+    public void setExternalRelation(final String externalRelation) {
         this.externalRelation = externalRelation;
     }
 
-    public void setExternalSource( final String externalSource ) {
+    public void setExternalSource(final String externalSource) {
         this.externalSource = externalSource;
     }
 
-    public void addDiscussion( final DiscussionRecord discussionRecord ) {
-        this.discussion.add( discussionRecord );
+    public void addDiscussion(final DiscussionRecord discussionRecord) {
+        this.discussion.add(discussionRecord);
     }
 
     public void eraseDiscussion() {
         this.discussion.clear();
     }
 
-    public void addTag( final String tag ) {
-        tags.add( tag );
+    public void addTag(final String tag) {
+        tags.add(tag);
     }
 
-    public void removeTag( final int idx ) {
-        tags.remove( idx );
+    public void removeTag(final int idx) {
+        tags.remove(idx);
     }
 
-    public void setDescription( final String description ) {
+    public void setDescription(final String description) {
         this.description = description;
     }
 
     @Override
-    public boolean equals( Object o ) {
-        if ( this == o ) {
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if ( o == null || getClass() != o.getClass() ) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
 
-        Metadata metadata = ( Metadata ) o;
+        Metadata metadata = (Metadata) o;
 
-        if ( tags != null ? !tags.equals( metadata.tags ) : metadata.tags != null ) {
+        if (tags != null ? !tags.equals(metadata.tags) : metadata.tags != null) {
             return false;
         }
-        if ( checkinComment != null ? !checkinComment.equals( metadata.checkinComment ) : metadata.checkinComment != null ) {
+        if (checkinComment != null ? !checkinComment.equals(metadata.checkinComment) : metadata.checkinComment != null) {
             return false;
         }
-        if ( creator != null ? !creator.equals( metadata.creator ) : metadata.creator != null ) {
+        if (creator != null ? !creator.equals(metadata.creator) : metadata.creator != null) {
             return false;
         }
-        if ( dateCreated != null ? !dateCreated.equals( metadata.dateCreated ) : metadata.dateCreated != null ) {
+        if (dateCreated != null ? !dateCreated.equals(metadata.dateCreated) : metadata.dateCreated != null) {
             return false;
         }
-        if ( description != null ? !description.equals( metadata.description ) : metadata.description != null ) {
+        if (description != null ? !description.equals(metadata.description) : metadata.description != null) {
             return false;
         }
-        if ( discussion != null ? !discussion.equals( metadata.discussion ) : metadata.discussion != null ) {
+        if (discussion != null ? !discussion.equals(metadata.discussion) : metadata.discussion != null) {
             return false;
         }
-        if ( externalRelation != null ? !externalRelation.equals( metadata.externalRelation ) : metadata.externalRelation != null ) {
+        if (externalRelation != null ? !externalRelation.equals(metadata.externalRelation) : metadata.externalRelation != null) {
             return false;
         }
-        if ( externalSource != null ? !externalSource.equals( metadata.externalSource ) : metadata.externalSource != null ) {
+        if (externalSource != null ? !externalSource.equals(metadata.externalSource) : metadata.externalSource != null) {
             return false;
         }
-        if ( lastContributor != null ? !lastContributor.equals( metadata.lastContributor ) : metadata.lastContributor != null ) {
+        if (lastContributor != null ? !lastContributor.equals(metadata.lastContributor) : metadata.lastContributor != null) {
             return false;
         }
-        if ( lastModified != null ? !lastModified.equals( metadata.lastModified ) : metadata.lastModified != null ) {
+        if (lastModified != null ? !lastModified.equals(metadata.lastModified) : metadata.lastModified != null) {
             return false;
         }
-        if ( path != null ? !path.equals( metadata.path ) : metadata.path != null ) {
+        if (path != null ? !path.equals(metadata.path) : metadata.path != null) {
             return false;
         }
-        if ( realPath != null ? !realPath.equals( metadata.realPath ) : metadata.realPath != null ) {
+        if (realPath != null ? !realPath.equals(metadata.realPath) : metadata.realPath != null) {
             return false;
         }
-        if ( subject != null ? !subject.equals( metadata.subject ) : metadata.subject != null ) {
+        if (subject != null ? !subject.equals(metadata.subject) : metadata.subject != null) {
             return false;
         }
-        if ( type != null ? !type.equals( metadata.type ) : metadata.type != null ) {
+        if (type != null ? !type.equals(metadata.type) : metadata.type != null) {
             return false;
         }
-        if ( version != null ? !version.equals( metadata.version ) : metadata.version != null ) {
+        if (version != null ? !version.equals(metadata.version) : metadata.version != null) {
             return false;
         }
-        if ( lockInfo != null ? !lockInfo.equals( metadata.lockInfo ) : metadata.lockInfo != null ) {
+        if (lockInfo != null ? !lockInfo.equals(metadata.lockInfo) : metadata.lockInfo != null) {
             return false;
         }
-        if ( generated != metadata.generated ) {
+        if (generated != metadata.generated) {
             return false;
         }
 
@@ -277,35 +277,33 @@ public class Metadata {
         result = ~~result;
         result = 31 * result + (realPath != null ? realPath.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( checkinComment != null ? checkinComment.hashCode() : 0 );
+        result = 31 * result + (checkinComment != null ? checkinComment.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( lastContributor != null ? lastContributor.hashCode() : 0 );
+        result = 31 * result + (lastContributor != null ? lastContributor.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( creator != null ? creator.hashCode() : 0 );
+        result = 31 * result + (creator != null ? creator.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( lastModified != null ? lastModified.hashCode() : 0 );
+        result = 31 * result + (lastModified != null ? lastModified.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( dateCreated != null ? dateCreated.hashCode() : 0 );
+        result = 31 * result + (dateCreated != null ? dateCreated.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( subject != null ? subject.hashCode() : 0 );
+        result = 31 * result + (subject != null ? subject.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( type != null ? type.hashCode() : 0 );
+        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( externalRelation != null ? externalRelation.hashCode() : 0 );
+        result = 31 * result + (externalRelation != null ? externalRelation.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( externalSource != null ? externalSource.hashCode() : 0 );
+        result = 31 * result + (externalSource != null ? externalSource.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( description != null ? description.hashCode() : 0 );
+        result = 31 * result + (description != null ? description.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( tags != null ? tags.hashCode() : 0 );
+        result = 31 * result + (tags != null ? tags.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( discussion != null ? discussion.hashCode() : 0 );
+        result = 31 * result + (discussion != null ? discussion.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( version != null ? version.hashCode() : 0 );
+        result = 31 * result + (version != null ? version.hashCode() : 0);
         result = ~~result;
-        result = 31 * result + ( lockInfo != null ? lockInfo.hashCode() : 0 );
-        result = ~~result;
-        result = 31 * result + ( generated ? 1 : 0 );
+        result = 31 * result + (generated ? 1 : 0);
         result = ~~result;
         return result;
     }

--- a/guvnor-services/guvnor-services-api/src/test/java/org/guvnor/common/services/shared/metadata/model/MetadataTest.java
+++ b/guvnor-services/guvnor-services-api/src/test/java/org/guvnor/common/services/shared/metadata/model/MetadataTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.shared.metadata.model;
+
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.backend.vfs.Path;
+import org.uberfire.backend.vfs.impl.LockInfo;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MetadataTest {
+
+    @Mock
+    private Path path;
+
+    private Date date = Calendar.getInstance().getTime();
+
+    private Metadata metadata;
+
+    @Test
+    public void checkLockInfoDoesNotAffectHashCode() {
+        this.metadata = new Metadata(path,
+                                     path,
+                                     "checkinComment",
+                                     "lastContributor",
+                                     "creator",
+                                     date,
+                                     date,
+                                     "subject",
+                                     "type",
+                                     "externalRelation",
+                                     "externalSource",
+                                     "description",
+                                     Collections.emptyList(),
+                                     Collections.emptyList(),
+                                     Collections.emptyList(),
+                                     new LockInfo(false,
+                                                  "",
+                                                  path),
+                                     false);
+
+        final int originalHashCode = metadata.hashCode();
+        metadata.setLockInfo(new LockInfo(true,
+                                          "admin",
+                                          path));
+
+        assertEquals(originalHashCode,
+                     metadata.hashCode());
+    }
+}


### PR DESCRIPTION
See https://issues.jboss.org/browse/GUVNOR-2976

This PR reinstates https://github.com/kiegroup/guvnor/commit/8e3676faa6e3790caaa7bf872f8c40db0a0c180f
which was inadvertently removed by https://github.com/kiegroup/guvnor/commit/f2cce32a65946a203b385667a64aeed51ee9d1b0