### PR TITLE
[6.5.x] RHBRMS-2792: [GSS] (6.4.z): WELD-001303 No active contexts for scope type javax.enterprise.context.RequestScoped in Tomcat

### DIFF
--- a/guvnor-inbox/guvnor-inbox-backend/src/main/java/org/guvnor/inbox/backend/server/InboxBackend.java
+++ b/guvnor-inbox/guvnor-inbox-backend/src/main/java/org/guvnor/inbox/backend/server/InboxBackend.java
@@ -17,23 +17,19 @@ package org.guvnor.inbox.backend.server;
 
 import java.util.List;
 
-/**
- * Created with IntelliJ IDEA.
- * Date: 9/30/13
- * Time: 4:06 PM
- * To change this template use File | Settings | File Templates.
- */
+import org.jboss.errai.security.shared.api.identity.User;
+
 public interface InboxBackend {
 
-    List<InboxEntry> loadRecentEdited( String userName );
+    List<InboxEntry> loadRecentEdited(User user);
 
-    List<InboxEntry> loadIncoming( String userName );
+    List<InboxEntry> loadIncoming(User user);
 
-    List<InboxEntry> readEntries( String userName,
-                                  String boxName );
+    List<InboxEntry> readEntries(User user,
+                                 String boxName);
 
-    void addToIncoming( String itemPath,
-                        String note,
-                        String userFrom,
-                        String userName );
+    void addToIncoming(String itemPath,
+                       String note,
+                       User userFrom,
+                       User userTo);
 }

--- a/guvnor-inbox/guvnor-inbox-backend/src/main/java/org/guvnor/inbox/backend/server/InboxServiceImpl.java
+++ b/guvnor-inbox/guvnor-inbox-backend/src/main/java/org/guvnor/inbox/backend/server/InboxServiceImpl.java
@@ -18,7 +18,6 @@ package org.guvnor.inbox.backend.server;
 import java.util.Iterator;
 import java.util.List;
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.context.SessionScoped;
 import javax.inject.Inject;
 
 import org.guvnor.inbox.model.InboxPageRequest;
@@ -42,62 +41,60 @@ public class InboxServiceImpl
     @Inject
     private InboxPageRowBuilder inboxPageRowBuilder;
 
-    public PageResponse<InboxPageRow> loadInbox( InboxPageRequest request ) {
-        if ( request == null ) {
-            throw new IllegalArgumentException( "request cannot be null" );
+    public PageResponse<InboxPageRow> loadInbox(InboxPageRequest request) {
+        if (request == null) {
+            throw new IllegalArgumentException("request cannot be null");
         }
-        if ( request.getPageSize() != null && request.getPageSize() < 0 ) {
-            throw new IllegalArgumentException( "pageSize cannot be less than zero." );
+        if (request.getPageSize() != null && request.getPageSize() < 0) {
+            throw new IllegalArgumentException("pageSize cannot be less than zero.");
         }
 
         String inboxName = request.getInboxName();
         PageResponse<InboxPageRow> response = new PageResponse<InboxPageRow>();
 
-        List<InboxEntry> entries = loadEntries( inboxName );
+        List<InboxEntry> entries = loadEntries(inboxName);
         Iterator<InboxEntry> iterator = entries.iterator();
         List<InboxPageRow> rowList = inboxPageRowBuilder
-                .withPageRequest( request )
-                .withIdentity( identity )
-                .withContent( iterator )
+                .withPageRequest(request)
+                .withIdentity(identity)
+                .withContent(iterator)
                 .build();
 
         response = new PageResponseBuilder<InboxPageRow>()
-                .withStartRowIndex( request.getStartRowIndex() )
-                .withTotalRowSize( entries.size() )
+                .withStartRowIndex(request.getStartRowIndex())
+                .withTotalRowSize(entries.size())
                 .withTotalRowSizeExact()
-                .withPageRowList( rowList )
-                .withLastPage( !iterator.hasNext() )
+                .withPageRowList(rowList)
+                .withLastPage(!iterator.hasNext())
                 .build();
 
         return response;
     }
 
-    private List<InboxEntry> loadEntries( final String inboxName ) {
+    private List<InboxEntry> loadEntries(final String inboxName) {
         List<InboxEntry> entries;
-        if ( inboxName.equals( RECENT_VIEWED_ID ) ) {
+        if (inboxName.equals(RECENT_VIEWED_ID)) {
             entries = loadRecentOpened();
-        } else if ( inboxName.equals( RECENT_EDITED_ID ) ) {
+        } else if (inboxName.equals(RECENT_EDITED_ID)) {
             entries = loadRecentEdited();
         } else {
             entries = loadIncoming();
-
         }
         return entries;
     }
 
     private List<InboxEntry> loadRecentEdited() {
-        return inboxBackend.readEntries( identity.getIdentifier(),
-                                         RECENT_EDITED_ID );
+        return inboxBackend.readEntries(identity,
+                                        RECENT_EDITED_ID);
     }
 
     private List<InboxEntry> loadRecentOpened() {
-        return inboxBackend.readEntries( identity.getIdentifier(),
-                                         RECENT_VIEWED_ID );
+        return inboxBackend.readEntries(identity,
+                                        RECENT_VIEWED_ID);
     }
 
     private List<InboxEntry> loadIncoming() {
-        return inboxBackend.readEntries( identity.getIdentifier(),
-                                         INCOMING_ID );
+        return inboxBackend.readEntries(identity,
+                                        INCOMING_ID);
     }
-
 }

--- a/guvnor-inbox/guvnor-inbox-backend/src/test/java/org/guvnor/inbox/backend/server/InboxBackendImplTest.java
+++ b/guvnor-inbox/guvnor-inbox-backend/src/test/java/org/guvnor/inbox/backend/server/InboxBackendImplTest.java
@@ -16,8 +16,14 @@
 
 package org.guvnor.inbox.backend.server;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.guvnor.inbox.backend.server.security.InboxEntrySecurity;
 import org.jboss.errai.security.shared.api.identity.User;
+import org.jboss.errai.security.shared.api.identity.UserImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.uberfire.backend.server.UserServicesBackendImpl;
@@ -28,11 +34,6 @@ import org.uberfire.java.nio.file.FileSystem;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.workbench.events.ResourceOpenedEvent;
 import org.uberfire.workbench.events.ResourceUpdatedEvent;
-
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.mockito.Mockito.*;
 
@@ -50,77 +51,99 @@ public class InboxBackendImplTest {
 
     @Before
     public void setup() {
-        ioService = mock( IOService.class );
-        systemFS = mock( FileSystem.class );
+        ioService = mock(IOService.class);
+        systemFS = mock(FileSystem.class);
         final InboxEntrySecurity security = new InboxEntrySecurity() {
             @Override
-            public List<InboxEntry> secure( List<InboxEntry> inboxEntries ) {
+            public List<InboxEntry> secure(List<InboxEntry> inboxEntries,
+                                           User user) {
                 return inboxEntries;
             }
         };
-        securitySpy = spy( security );
-        userServicesBackend = mock( UserServicesBackendImpl.class );
-        mailboxService = mock( MailboxService.class );
-        sessionInfo = mock( SessionInfo.class );
-        final User user = mock( User.class );
+        securitySpy = spy(security);
+        userServicesBackend = mock(UserServicesBackendImpl.class);
+        mailboxService = mock(MailboxService.class);
+        sessionInfo = mock(SessionInfo.class);
+        final User user = mock(User.class);
 
-        when( sessionInfo.getIdentity() ).thenReturn( user );
-        when( user.getIdentifier() ).thenReturn( "user1" );
+        when(sessionInfo.getIdentity()).thenReturn(user);
+        when(user.getIdentifier()).thenReturn("user1");
 
-        resourcePath = mock( Path.class );
-        mockedFSId = mock( FileSystem.class, withSettings().extraInterfaces( FileSystemId.class ) );
+        resourcePath = mock(Path.class);
+        mockedFSId = mock(FileSystem.class,
+                          withSettings().extraInterfaces(FileSystemId.class));
 
-        when( resourcePath.toURI() ).thenReturn( URI.create( "jgit://repo/my-file.txt" ).toString() );
-        when( resourcePath.getFileName() ).thenReturn( "my-file.txt" );
+        when(resourcePath.toURI()).thenReturn(URI.create("jgit://repo/my-file.txt").toString());
+        when(resourcePath.getFileName()).thenReturn("my-file.txt");
 
-        final org.uberfire.java.nio.file.Path rootPath = mock( org.uberfire.java.nio.file.Path.class );
+        final org.uberfire.java.nio.file.Path rootPath = mock(org.uberfire.java.nio.file.Path.class);
 
-        when( systemFS.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
-        when( mockedFSId.getRootDirectories() ).thenReturn( Arrays.asList( rootPath ) );
+        when(systemFS.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
+        when(mockedFSId.getRootDirectories()).thenReturn(Arrays.asList(rootPath));
 
-        when( rootPath.getFileSystem() ).thenReturn( mockedFSId );
-        when( ( ( FileSystemId ) mockedFSId ).id() ).thenReturn( "my-fsid" );
-
+        when(rootPath.getFileSystem()).thenReturn(mockedFSId);
+        when(((FileSystemId) mockedFSId).id()).thenReturn("my-fsid");
     }
 
     @Test
     public void testCheckBatch() {
-        inboxBackend = new InboxBackendImpl( ioService, systemFS, userServicesBackend, mailboxService, securitySpy );
+        inboxBackend = new InboxBackendImpl(ioService,
+                                            systemFS,
+                                            userServicesBackend,
+                                            mailboxService,
+                                            securitySpy);
 
-        inboxBackend.recordOpeningEvent( new ResourceOpenedEvent( resourcePath, sessionInfo ) );
+        inboxBackend.recordOpeningEvent(new ResourceOpenedEvent(resourcePath,
+                                                                sessionInfo));
 
-        verify( ioService, times( 1 ) ).startBatch( mockedFSId );
+        verify(ioService,
+               times(1)).startBatch(mockedFSId);
 
-        verify( ioService, times( 1 ) ).endBatch();
+        verify(ioService,
+               times(1)).endBatch();
 
-        inboxBackend.recordUserEditEvent( new ResourceUpdatedEvent( resourcePath, "message", sessionInfo ) );
+        inboxBackend.recordUserEditEvent(new ResourceUpdatedEvent(resourcePath,
+                                                                  "message",
+                                                                  sessionInfo));
 
-        verify( ioService, times( 2 ) ).startBatch( mockedFSId );
+        verify(ioService,
+               times(2)).startBatch(mockedFSId);
 
-        verify( ioService, times( 2 ) ).endBatch();
-
+        verify(ioService,
+               times(2)).endBatch();
     }
 
     @Test
     public void readShouldSecureItems() {
-        org.uberfire.java.nio.file.Path path = mock( org.uberfire.java.nio.file.Path.class );
-        when( userServicesBackend.buildPath( "userName", "inbox", "boxName" ) ).thenReturn( path );
-        when( ioService.exists( path ) ).thenReturn( true );
-        when( ioService.readAllString( path ) ).thenReturn( " " );
+        org.uberfire.java.nio.file.Path path = mock(org.uberfire.java.nio.file.Path.class);
+        when(userServicesBackend.buildPath("userName",
+                                           "inbox",
+                                           "boxName")).thenReturn(path);
+        when(ioService.exists(path)).thenReturn(true);
+        when(ioService.readAllString(path)).thenReturn(" ");
         final List<InboxEntry> entries = new ArrayList<InboxEntry>();
-        final InboxEntry inboxEntry1 = new InboxEntry( "path1", "note1", "user1" );
-        entries.add( inboxEntry1 );
+        final InboxEntry inboxEntry1 = new InboxEntry("path1",
+                                                      "note1",
+                                                      "user1");
+        entries.add(inboxEntry1);
 
-        inboxBackend = new InboxBackendImpl( ioService, systemFS, userServicesBackend, mailboxService, securitySpy ) {
+        inboxBackend = new InboxBackendImpl(ioService,
+                                            systemFS,
+                                            userServicesBackend,
+                                            mailboxService,
+                                            securitySpy) {
             @Override
-            List<InboxEntry> getInboxEntries( String xml ) {
+            List<InboxEntry> getInboxEntries(String xml) {
 
                 return entries;
             }
         };
 
-        inboxBackend.readEntries( "userName", "boxName" );
+        final User user = new UserImpl("userName");
+        inboxBackend.readEntries(user,
+                                 "boxName");
 
-        verify( securitySpy ).secure( entries );
+        verify(securitySpy).secure(entries,
+                                   user);
     }
 }

--- a/guvnor-inbox/guvnor-inbox-backend/src/test/java/org/guvnor/inbox/backend/server/security/InboxEntrySecurity_InboxEntrySecurityTestTest.java
+++ b/guvnor-inbox/guvnor-inbox-backend/src/test/java/org/guvnor/inbox/backend/server/security/InboxEntrySecurity_InboxEntrySecurityTestTest.java
@@ -20,7 +20,6 @@ import org.guvnor.structure.backend.repositories.ConfiguredRepositories;
 import org.guvnor.structure.organizationalunit.OrganizationalUnitService;
 import org.guvnor.structure.repositories.Repository;
 import org.guvnor.test.TestFileSystem;
-import org.jboss.errai.security.shared.api.identity.User;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +32,7 @@ import org.uberfire.security.authz.AuthorizationManager;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-@RunWith( MockitoJUnitRunner.class )
+@RunWith(MockitoJUnitRunner.class)
 public class InboxEntrySecurity_InboxEntrySecurityTestTest {
 
     @Mock
@@ -43,54 +42,55 @@ public class InboxEntrySecurity_InboxEntrySecurityTestTest {
     private Repository repository;
 
     private InboxEntrySecurity inbox;
-    private TestFileSystem     testFileSystem;
+    private TestFileSystem testFileSystem;
 
     @Before
     public void setup() {
         testFileSystem = new TestFileSystem();
 
-        when( configuredRepositories.getRepositoryByRepositoryFileSystem( any( FileSystem.class ) ) ).thenReturn( repository );
+        when(configuredRepositories.getRepositoryByRepositoryFileSystem(any(FileSystem.class))).thenReturn(repository);
 
-        inbox = new InboxEntrySecurity( mock( User.class ),
-                                        mock( AuthorizationManager.class ),
-                                        mock( OrganizationalUnitService.class ),
-                                        mock( ProjectService.class ),
-                                        configuredRepositories );
+        inbox = new InboxEntrySecurity(mock(AuthorizationManager.class),
+                                       mock(OrganizationalUnitService.class),
+                                       mock(ProjectService.class),
+                                       configuredRepositories);
     }
 
     @Test
     public void testWorkingURI() throws Exception {
 
-        final Path tempFile = testFileSystem.createTempFile( "text.txt" );
+        final Path tempFile = testFileSystem.createTempFile("text.txt");
 
-        final InboxEntry entry = new InboxEntry( tempFile.toURI(),
-                                                 "note",
-                                                 "userFrom" );
+        final InboxEntry entry = new InboxEntry(tempFile.toURI(),
+                                                "note",
+                                                "userFrom");
 
-        assertEquals( repository, inbox.getInboxEntryRepository( entry ) );
+        assertEquals(repository,
+                     inbox.getInboxEntryRepository(entry));
     }
 
     @Test
     public void testFileRemoved() throws Exception {
 
-        final Path tempFile = testFileSystem.createTempFile( "text.txt" );
+        final Path tempFile = testFileSystem.createTempFile("text.txt");
 
-        testFileSystem.deleteFile( tempFile );
+        testFileSystem.deleteFile(tempFile);
 
-        final InboxEntry entry = new InboxEntry( tempFile.toURI(),
-                                                 "note",
-                                                 "userFrom" );
+        final InboxEntry entry = new InboxEntry(tempFile.toURI(),
+                                                "note",
+                                                "userFrom");
 
-        assertEquals( repository, inbox.getInboxEntryRepository( entry ) );
+        assertEquals(repository,
+                     inbox.getInboxEntryRepository(entry));
     }
 
     @Test
     public void testBrokenURI() throws Exception {
 
-        final InboxEntry entry = new InboxEntry( "git://master@broken",
-                                                 "note",
-                                                 "userFrom" );
+        final InboxEntry entry = new InboxEntry("git://master@broken",
+                                                "note",
+                                                "userFrom");
 
-        assertNull( inbox.getInboxEntryRepository( entry ) );
+        assertNull(inbox.getInboxEntryRepository(entry));
     }
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2792

@tkobayas Hi, you could try this change locally on Tomcat.

It removes injection of "User" to a method parameter that can be correctly provided from the client.

If it solves the issue we can merge into our 6.5.x.