### PR TITLE
[GUVNOR-2996]: Different Repositories added to separate logic into independent components

### DIFF
--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-api/pom.xml
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-api/pom.xml
@@ -51,7 +51,23 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-api</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
+
   </dependencies>
 
 </project>

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/model/JarListPageRow.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/model/JarListPageRow.java
@@ -32,12 +32,13 @@ public class JarListPageRow extends AbstractPageRow {
     private String path;
     private GAV gav;
     private Date lastModified;
+    private String repository;
 
     public String getName() {
         return name;
     }
 
-    public void setName( String name ) {
+    public void setName(String name) {
         this.name = name;
     }
 
@@ -45,7 +46,7 @@ public class JarListPageRow extends AbstractPageRow {
         return path;
     }
 
-    public void setPath( String path ) {
+    public void setPath(String path) {
         this.path = path;
     }
 
@@ -53,7 +54,7 @@ public class JarListPageRow extends AbstractPageRow {
         return gav;
     }
 
-    public void setGav( GAV gav ) {
+    public void setGav(GAV gav) {
         this.gav = gav;
     }
 
@@ -61,8 +62,15 @@ public class JarListPageRow extends AbstractPageRow {
         return lastModified;
     }
 
-    public void setLastModified( Date lastModified ) {
+    public void setLastModified(Date lastModified) {
         this.lastModified = lastModified;
     }
 
+    public String getRepositoryName() {
+        return repository;
+    }
+
+    public void setRepositoryName(final String repository) {
+        this.repository = repository;
+    }
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/preferences/ArtifactRepositoryPreference.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/preferences/ArtifactRepositoryPreference.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.preferences;
+
+import org.uberfire.preferences.shared.annotations.Property;
+import org.uberfire.preferences.shared.annotations.WorkbenchPreference;
+import org.uberfire.preferences.shared.bean.BasePreference;
+
+@WorkbenchPreference(identifier = "ArtifactRepositoryPreference", bundleKey = "ArtifactRepositoryPreference.Label")
+public class ArtifactRepositoryPreference implements BasePreference<ArtifactRepositoryPreference> {
+
+    @Property(bundleKey = "ArtifactRepositoryPreference.DefaultM2RepoDir")
+    private String defaultM2RepoDir;
+
+    @Override
+    public ArtifactRepositoryPreference defaultValue(final ArtifactRepositoryPreference defaultValue) {
+        defaultValue.defaultM2RepoDir = "repositories/kie";
+        return defaultValue;
+    }
+
+    public String getDefaultM2RepoDir() {
+        return defaultM2RepoDir;
+    }
+
+    public void setDefaultM2RepoDir(final String defaultM2RepoDir) {
+        this.defaultM2RepoDir = defaultM2RepoDir.trim();
+    }
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/resources/org/guvnor/m2repo/GuvnorM2RepoEditorAPI.gwt.xml
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/resources/org/guvnor/m2repo/GuvnorM2RepoEditorAPI.gwt.xml
@@ -21,10 +21,13 @@
 <module>
 
   <inherits name='org.guvnor.common.services.project.GuvnorProjectAPI'/>
+  <inherits name="org.uberfire.java.nio.UberfireNIO2Model"/>
+  <inherits name="org.jboss.errai.bus.ErraiBus"/>
 
   <source path="model"/>
+  <source path="preferences"/>
   <source path="service"/>
-  <source path="security" />
+  <source path="security"/>
   <source path="utils"/>
 
 </module>

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/pom.xml
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/pom.xml
@@ -125,6 +125,32 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-nio2-model</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-backend</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-processors</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-common</artifactId>
+    </dependency>
+
     <!-- The version of commons-io in droolsjbpm-build-bootstrap pom is way too old-->
     <dependency>
       <groupId>commons-io</groupId>

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/ArtifactImpl.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/ArtifactImpl.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server;
+
+import java.io.File;
+import java.util.Map;
+
+import org.eclipse.aether.artifact.Artifact;
+
+public class ArtifactImpl implements Artifact {
+
+    private String groupId;
+    private String artifactId;
+    private String version;
+    private String baseVersion;
+    private boolean snapshot;
+    private String classifier;
+    private String extension;
+    private File file;
+    private Map<String, String> properties;
+
+    public ArtifactImpl(final File file) {
+        this.setFile(file);
+    }
+
+    @Override
+    public String getGroupId() {
+        return this.groupId;
+    }
+
+    @Override
+    public String getArtifactId() {
+        return this.artifactId;
+    }
+
+    @Override
+    public String getVersion() {
+        return this.version;
+    }
+
+    @Override
+    public Artifact setVersion(final String version) {
+        this.version = version;
+        return this;
+    }
+
+    @Override
+    public String getBaseVersion() {
+        return this.baseVersion;
+    }
+
+    @Override
+    public boolean isSnapshot() {
+        return this.snapshot;
+    }
+
+    @Override
+    public String getClassifier() {
+        return this.classifier;
+    }
+
+    @Override
+    public String getExtension() {
+        return this.extension;
+    }
+
+    @Override
+    public File getFile() {
+        return this.file;
+    }
+
+    @Override
+    public Artifact setFile(final File file) {
+        this.file = file;
+        return this;
+    }
+
+    @Override
+    public String getProperty(final String s,
+                              final String s1) {
+        return this.properties.getOrDefault(s,
+                                            s1);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return this.properties;
+    }
+
+    @Override
+    public Artifact setProperties(final Map<String, String> map) {
+        this.properties = map;
+        return this;
+    }
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
@@ -16,7 +16,6 @@
 
 package org.guvnor.m2repo.backend.server;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -26,13 +25,12 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.net.MalformedURLException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
@@ -40,83 +38,83 @@ import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOCase;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.io.filefilter.DirectoryFileFilter;
-import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.apache.maven.model.DeploymentRepository;
-import org.apache.maven.model.DistributionManagement;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
-import org.apache.maven.project.MavenProject;
-import org.apache.maven.project.ProjectBuildingException;
-import org.apache.maven.settings.Server;
-import org.apache.maven.settings.Settings;
 import org.codehaus.plexus.util.IOUtil;
 import org.drools.core.io.impl.ReaderInputStream;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.deployment.DeployRequest;
-import org.eclipse.aether.deployment.DeploymentException;
-import org.eclipse.aether.installation.InstallRequest;
-import org.eclipse.aether.installation.InstallationException;
-import org.eclipse.aether.repository.Authentication;
-import org.eclipse.aether.repository.RemoteRepository;
-import org.eclipse.aether.repository.RepositoryPolicy;
-import org.eclipse.aether.resolution.ArtifactRequest;
-import org.eclipse.aether.resolution.ArtifactResolutionException;
-import org.eclipse.aether.resolution.ArtifactResult;
 import org.eclipse.aether.util.artifact.SubArtifact;
 import org.guvnor.common.services.project.model.GAV;
-import org.kie.scanner.Aether;
-import org.kie.scanner.embedder.MavenEmbedder;
-import org.kie.scanner.embedder.MavenEmbedderException;
-import org.kie.scanner.embedder.MavenProjectLoader;
-import org.kie.scanner.embedder.MavenSettings;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepository;
+import org.guvnor.m2repo.backend.server.repositories.DistributionManagementArtifactRepository;
+import org.guvnor.m2repo.backend.server.repositories.FileSystemArtifactRepository;
+import org.guvnor.m2repo.backend.server.repositories.LocalArtifactRepository;
+import org.guvnor.m2repo.preferences.ArtifactRepositoryPreference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.uberfire.apache.commons.io.FilenameUtils;
 
 import static org.guvnor.m2repo.utils.FileNameUtilities.*;
 
 @ApplicationScoped
 public class GuvnorM2Repository {
 
-    private static final Logger log = LoggerFactory.getLogger( GuvnorM2Repository.class );
+    private static final Logger log = LoggerFactory.getLogger(GuvnorM2Repository.class);
 
-    public static final String M2_REPO_ROOT = "repositories" + File.separatorChar + "kie";
     public static String M2_REPO_DIR;
 
     private static final int BUFFER_SIZE = 1024;
 
+    private final List<ArtifactRepository> repositories = new ArrayList<>();
+    private final List<ArtifactRepository> pomRepositories = new ArrayList<>();
+
+    private ArtifactRepositoryPreference preferences;
+
+    public GuvnorM2Repository() {
+    }
+
+    @Inject
+    public GuvnorM2Repository(ArtifactRepositoryPreference preferences) {
+        this.preferences = preferences;
+    }
+
     @PostConstruct
     public void init() {
+        preferences.load();
         setM2Repos();
     }
 
     private void setM2Repos() {
-        final String meReposDir = System.getProperty( "org.guvnor.m2repo.dir" );
+        final String M2_REPO_ROOT = FilenameUtils.separatorsToSystem(preferences.getDefaultM2RepoDir());
 
-        if ( meReposDir == null || meReposDir.trim().isEmpty() ) {
+        final String meReposDir = System.getProperty("org.guvnor.m2repo.dir");
+
+        if (meReposDir == null || meReposDir.trim().isEmpty()) {
             M2_REPO_DIR = M2_REPO_ROOT;
         } else {
             M2_REPO_DIR = meReposDir.trim();
         }
-        log.info( "Maven Repository root set to: " + M2_REPO_DIR );
 
-        //Ensure repository root has been created
-        final File root = new File( getM2RepositoryRootDir() );
-        if ( !root.exists() ) {
-            log.info( "Creating Maven Repository root: " + M2_REPO_DIR );
-            root.mkdirs();
-        }
+        final LocalArtifactRepository localRepository = new LocalArtifactRepository("local-m2-repo");
+        final FileSystemArtifactRepository fileSystemRepository = new FileSystemArtifactRepository("guvnor-m2-repo",
+                                                                                                   this.M2_REPO_DIR);
+        final DistributionManagementArtifactRepository distributionManagementArtifactRepository = new DistributionManagementArtifactRepository("distribution-management-repo");
 
-        Aether.getAether().getRepositories().add( getGuvnorM2Repository() );
+        repositories.add(localRepository);
+        repositories.add(fileSystemRepository);
+        repositories.add(distributionManagementArtifactRepository);
+
+        pomRepositories.add(localRepository);
+        pomRepositories.add(fileSystemRepository);
     }
 
     public String getM2RepositoryRootDir() {
-        if ( !M2_REPO_DIR.endsWith( File.separator ) ) {
+        if (!M2_REPO_DIR.endsWith(File.separator)) {
             return M2_REPO_DIR + File.separator;
         } else {
             return M2_REPO_DIR;
@@ -124,405 +122,229 @@ public class GuvnorM2Repository {
     }
 
     public String getRepositoryURL() {
-        File file = new File( getM2RepositoryRootDir() );
+        File file = new File(getM2RepositoryRootDir());
         return "file://" + file.getAbsolutePath();
     }
 
-    public void deployArtifact( final InputStream jarStream,
-                                final GAV gav,
-                                final boolean includeAdditionalRepositories ) {
+    public void deployArtifact(final InputStream jarStream,
+                               final GAV gav,
+                               final boolean includeAdditionalRepositories) {
         //Write JAR to temporary file for deployment
-        File jarFile = new File( System.getProperty( "java.io.tmpdir" ),
-                                 toFileName( gav,
-                                             "jar" ) );
+        File jarFile = new File(System.getProperty("java.io.tmpdir"),
+                                toFileName(gav,
+                                           "jar"));
 
         try {
 
-            try {
-                if ( !jarFile.exists() ) {
-                    jarFile.getParentFile().mkdirs();
-                    jarFile.createNewFile();
-                }
-                FileOutputStream fos = new FileOutputStream( jarFile );
-
-                final byte[] buf = new byte[ BUFFER_SIZE ];
-                int byteRead = 0;
-                while ( ( byteRead = jarStream.read( buf ) ) != -1 ) {
-                    fos.write( buf, 0, byteRead );
-                }
-                fos.flush();
-                fos.close();
-            } catch ( IOException e ) {
-                throw new RuntimeException( e );
-            }
+            inputStreamToFile(jarStream,
+                              jarFile);
 
             //Write pom.xml to JAR if it doesn't already exist
-            String pomXML = loadPomFromJar( new File( jarFile.getPath() ) );
-            if ( pomXML == null ) {
-                pomXML = generatePOM( gav );
-                jarFile = appendPOMToJar( pomXML,
-                                          jarFile.getPath(),
-                                          gav );
+            String pomXML = loadPomFromJar(new File(jarFile.getPath()));
+            if (pomXML == null) {
+                pomXML = generatePOM(gav);
+                jarFile = appendFileToJar(pomXML,
+                                          getPomXmlPath(gav),
+                                          jarFile.getPath());
             }
 
             //Write pom.properties to JAR if it doesn't already exist
-            String pomProperties = loadGAVFromJarInternal( new File( jarFile.getPath() ) );
-            if ( pomProperties == null ) {
-                pomProperties = generatePomProperties( gav );
-                jarFile = appendPomPropertiesToJar( pomProperties,
-                                                    jarFile.getPath(),
-                                                    gav );
+            String pomProperties = loadGAVFromJarInternal(new File(jarFile.getPath()));
+            if (pomProperties == null) {
+                pomProperties = generatePomProperties(gav);
+                jarFile = appendFileToJar(pomProperties,
+                                          getPomPropertiesPath(gav),
+                                          jarFile.getPath());
             }
 
-            deployArtifact( gav,
-                            pomXML,
-                            jarFile,
-                            includeAdditionalRepositories );
-
+            deployArtifact(gav,
+                           pomXML,
+                           jarFile,
+                           includeAdditionalRepositories);
         } finally {
             try {
                 jarFile.delete();
-            } catch ( Exception e ) {
-                log.warn( "Unable to remove temporary file '" + jarFile.getAbsolutePath() + "'" );
+            } catch (Exception e) {
+                log.warn("Unable to remove temporary file '" + jarFile.getAbsolutePath() + "'");
             }
         }
     }
 
-    public void deployPom( final InputStream pomStream,
-                           final GAV gav ) {
+    public void deployPom(final InputStream pomStream,
+                          final GAV gav) {
         //Write POM to temporary file for deployment
-        File pomFile = new File( System.getProperty( "java.io.tmpdir" ),
-                                 toFileName( gav,
-                                             "pom" ) );
+        File pomFile = new File(System.getProperty("java.io.tmpdir"),
+                                toFileName(gav,
+                                           "pom"));
 
         try {
 
-            try {
-                if ( !pomFile.exists() ) {
-                    pomFile.getParentFile().mkdirs();
-                    pomFile.createNewFile();
-                }
-                FileOutputStream fos = new FileOutputStream( pomFile );
+            inputStreamToFile(pomStream,
+                              pomFile);
 
-                final byte[] buf = new byte[ BUFFER_SIZE ];
-                int byteRead = 0;
-                while ( ( byteRead = pomStream.read( buf ) ) != -1 ) {
-                    fos.write( buf, 0, byteRead );
-                }
-                fos.flush();
-                fos.close();
-            } catch ( IOException e ) {
-                throw new RuntimeException( e );
-            }
-
-            deployPom( gav,
-                       pomFile );
-
+            deployPom(gav,
+                      pomFile);
         } finally {
             try {
                 pomFile.delete();
-            } catch ( Exception e ) {
-                log.warn( "Unable to remove temporary file '" + pomFile.getAbsolutePath() + "'" );
+            } catch (Exception e) {
+                log.warn("Unable to remove temporary file '" + pomFile.getAbsolutePath() + "'");
             }
         }
     }
 
-    public void deployParentPom( final GAV gav ) {
+    private void inputStreamToFile(final InputStream inputStream,
+                                   final File file) {
+
+        FileOutputStream fos = null;
+        try {
+            if (!file.exists()) {
+                file.getParentFile().mkdirs();
+                file.createNewFile();
+            }
+            fos = new FileOutputStream(file);
+
+            final byte[] buf = new byte[BUFFER_SIZE];
+            int byteRead = 0;
+            while ((byteRead = inputStream.read(buf)) != -1) {
+                fos.write(buf,
+                          0,
+                          byteRead);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (fos != null) {
+                try {
+                    fos.flush();
+                    fos.close();
+                } catch (IOException e) {
+                    log.error("Error occurred when trying to close stream",
+                              e);
+                }
+            }
+        }
+    }
+
+    public void deployParentPom(final GAV gav) {
         //Write pom.xml to temporary file for deployment
-        final File pomXMLFile = new File( System.getProperty( "java.io.tmpdir" ),
-                                          toFileName( gav,
-                                                      "pom.xml" ) );
+        final File pomXMLFile = new File(System.getProperty("java.io.tmpdir"),
+                                         toFileName(gav,
+                                                    "pom.xml"));
 
         try {
 
-            String pomXML = generateParentPOM( gav );
-            try {
-                if ( !pomXMLFile.exists() ) {
-                    pomXMLFile.getParentFile().mkdirs();
-                    pomXMLFile.createNewFile();
-                }
-
-                FileOutputStream fos = new FileOutputStream( pomXMLFile );
-                IOUtils.write( pomXML,
-                               fos );
-
-                fos.flush();
-                fos.close();
-            } catch ( IOException e ) {
-                throw new RuntimeException( e );
-            }
+            String pomXML = generateParentPOM(gav);
+            writeStringIntoFile(pomXML,
+                                pomXMLFile);
             //pom.xml Artifact
-            Artifact pomXMLArtifact = new DefaultArtifact( gav.getGroupId(),
-                                                           gav.getArtifactId(),
-                                                           "pom",
-                                                           gav.getVersion() );
-            pomXMLArtifact = pomXMLArtifact.setFile( pomXMLFile );
+            Artifact pomXMLArtifact = new DefaultArtifact(gav.getGroupId(),
+                                                          gav.getArtifactId(),
+                                                          "pom",
+                                                          gav.getVersion());
+            pomXMLArtifact = pomXMLArtifact.setFile(pomXMLFile);
 
-            try {
-                //Install into local repository
-                final InstallRequest installRequest = new InstallRequest();
-                installRequest
-                        .addArtifact( pomXMLArtifact );
-
-                Aether.getAether().getSystem().install( Aether.getAether().getSession(),
-                                                        installRequest );
-            } catch ( InstallationException e ) {
-                throw new RuntimeException( e );
-            }
-
-            //Deploy into Workbench's default remote repository
-            try {
-                final DeployRequest deployRequest = new DeployRequest();
-                deployRequest
-                        .addArtifact( pomXMLArtifact )
-                        .setRepository( getGuvnorM2Repository() );
-
-                Aether.getAether().getSystem().deploy( Aether.getAether().getSession(),
-                                                       deployRequest );
-
-            } catch ( DeploymentException e ) {
-                throw new RuntimeException( e );
-            }
-
+            final Artifact finalPomXMLArtifact = pomXMLArtifact;
+            this.pomRepositories.forEach(artifactRepository -> {
+                artifactRepository.deploy(pomXML,
+                                          finalPomXMLArtifact);
+            });
         } finally {
             try {
                 pomXMLFile.delete();
-            } catch ( Exception e ) {
-                log.warn( "Unable to remove temporary file '" + pomXMLFile.getAbsolutePath() + "'" );
+            } catch (Exception e) {
+                log.warn("Unable to remove temporary file '" + pomXMLFile.getAbsolutePath() + "'");
             }
         }
     }
 
-    private void deployArtifact( final GAV gav,
-                                 final String pomXML,
-                                 final File jarFile,
-                                 final boolean includeAdditionalRepositories ) {
+    private void deployArtifact(final GAV gav,
+                                final String pomXML,
+                                final File jarFile,
+                                final boolean includeAdditionalRepositories) {
         //Write pom.xml to temporary file for deployment
-        final File pomXMLFile = new File( System.getProperty( "java.io.tmpdir" ),
-                                          toFileName( gav,
-                                                      "pom.xml" ) );
+        final File pomXMLFile = new File(System.getProperty("java.io.tmpdir"),
+                                         toFileName(gav,
+                                                    "pom.xml"));
 
         try {
 
-            try {
-                if ( !pomXMLFile.exists() ) {
-                    pomXMLFile.getParentFile().mkdirs();
-                    pomXMLFile.createNewFile();
-                }
-
-                FileOutputStream fos = new FileOutputStream( pomXMLFile );
-                IOUtils.write( pomXML,
-                               fos );
-
-                fos.flush();
-                fos.close();
-            } catch ( IOException e ) {
-                throw new RuntimeException( e );
-            }
+            writeStringIntoFile(pomXML,
+                                pomXMLFile);
 
             //JAR Artifact
-            Artifact jarArtifact = new DefaultArtifact( gav.getGroupId(),
-                                                        gav.getArtifactId(),
-                                                        "jar",
-                                                        gav.getVersion() );
-            jarArtifact = jarArtifact.setFile( jarFile );
+            Artifact jarArtifact = new DefaultArtifact(gav.getGroupId(),
+                                                       gav.getArtifactId(),
+                                                       "jar",
+                                                       gav.getVersion());
+            jarArtifact = jarArtifact.setFile(jarFile);
 
             //pom.xml Artifact
-            Artifact pomXMLArtifact = new SubArtifact( jarArtifact,
-                                                       "",
-                                                       "pom" );
-            pomXMLArtifact = pomXMLArtifact.setFile( pomXMLFile );
+            Artifact pomXMLArtifact = new SubArtifact(jarArtifact,
+                                                      "",
+                                                      "pom");
+            pomXMLArtifact = pomXMLArtifact.setFile(pomXMLFile);
 
-            try {
-                //Install into local repository
-                final InstallRequest installRequest = new InstallRequest();
-                installRequest
-                        .addArtifact( jarArtifact )
-                        .addArtifact( pomXMLArtifact );
-
-                Aether.getAether().getSystem().install( Aether.getAether().getSession(),
-                                                        installRequest );
-            } catch ( InstallationException e ) {
-                throw new RuntimeException( e );
-            }
-
-            //Deploy into Workbench's default remote repository
-            try {
-                final DeployRequest deployRequest = new DeployRequest();
-                deployRequest
-                        .addArtifact( jarArtifact )
-                        .addArtifact( pomXMLArtifact )
-                        .setRepository( getGuvnorM2Repository() );
-
-                Aether.getAether().getSystem().deploy( Aether.getAether().getSession(),
-                                                       deployRequest );
-
-            } catch ( DeploymentException e ) {
-                throw new RuntimeException( e );
-            }
+            final Artifact finalJarArtifact = jarArtifact;
+            final Artifact finalPomXMLArtifact = pomXMLArtifact;
+            this.repositories.forEach((repository) -> repository.deploy(pomXML,
+                                                                        finalJarArtifact,
+                                                                        finalPomXMLArtifact));
 
             //Only deploy to additional repositories if required. This flag is principally for Unit Tests
-            if ( !includeAdditionalRepositories ) {
+            if (!includeAdditionalRepositories) {
                 return;
             }
-
-            //Deploy into remote repository defined in <distributionManagement>
-            try {
-                MavenEmbedder embedder = MavenProjectLoader.newMavenEmbedder( false );
-                DistributionManagement distributionManagement = getDistributionManagement( pomXML, embedder );
-
-                if ( distributionManagement != null ) {
-
-                    final boolean isSnapshot = pomXMLArtifact.isSnapshot();
-                    DeploymentRepository remoteRepository = null;
-                    if ( isSnapshot ) {
-                        remoteRepository = distributionManagement.getSnapshotRepository();
-
-                        //Maven documentation states use of the regular repository if the SNAPSHOT repository is undefined
-                        //See https://maven.apache.org/pom.html#Repository and https://bugzilla.redhat.com/show_bug.cgi?id=1129573
-                        if ( remoteRepository == null ) {
-                            remoteRepository = distributionManagement.getRepository();
-                        }
-                    } else {
-                        remoteRepository = distributionManagement.getRepository();
-                    }
-
-                    //If the user has configured a distribution management module in the pom then we will attempt to deploy there.
-                    //If credentials are required those credentials must be provisioned in the user's settings.xml file
-                    if ( remoteRepository != null ) {
-                        DeployRequest remoteRequest = new DeployRequest();
-                        remoteRequest
-                                .addArtifact( jarArtifact )
-                                .addArtifact( pomXMLArtifact )
-                                .setRepository( getRemoteRepoFromDeployment( remoteRepository, embedder ) );
-
-                        Aether.getAether().getSystem().deploy( Aether.getAether().getSession(),
-                                                               remoteRequest );
-                    }
-                }
-
-            } catch ( DeploymentException e ) {
-                throw new RuntimeException( e );
-            }
-
         } finally {
             try {
                 pomXMLFile.delete();
-            } catch ( Exception e ) {
-                log.warn( "Unable to remove temporary file '" + pomXMLFile.getAbsolutePath() + "'" );
+            } catch (Exception e) {
+                log.warn("Unable to remove temporary file '" + pomXMLFile.getAbsolutePath() + "'");
             }
         }
     }
 
-    private void deployPom( final GAV gav,
-                            final File pomFile ) {
-        //POM Artifact
-        Artifact pomArtifact = new DefaultArtifact( gav.getGroupId(),
-                                                    gav.getArtifactId(),
-                                                    "pom",
-                                                    gav.getVersion() );
-        pomArtifact = pomArtifact.setFile( pomFile );
-
+    private void writeStringIntoFile(final String string,
+                                     final File file) {
+        FileOutputStream fos = null;
         try {
-            //Install into local repository
-            final InstallRequest installRequest = new InstallRequest();
-            installRequest
-                    .addArtifact( pomArtifact );
+            if (!file.exists()) {
+                file.getParentFile().mkdirs();
+                file.createNewFile();
+            }
 
-            Aether.getAether().getSystem().install( Aether.getAether().getSession(),
-                                                    installRequest );
-        } catch ( InstallationException e ) {
-            throw new RuntimeException( e );
-        }
-
-        //Deploy into Workbench's default remote repository
-        try {
-            final DeployRequest deployRequest = new DeployRequest();
-            deployRequest
-                    .addArtifact( pomArtifact )
-                    .setRepository( getGuvnorM2Repository() );
-
-            Aether.getAether().getSystem().deploy( Aether.getAether().getSession(),
-                                                   deployRequest );
-
-        } catch ( DeploymentException e ) {
-            throw new RuntimeException( e );
-        }
-    }
-
-    private DistributionManagement getDistributionManagement( final String pomXML,
-                                                              final MavenEmbedder embedder ) {
-        final InputStream is = new ByteArrayInputStream( pomXML.getBytes( Charset.forName( "UTF-8" ) ) );
-        MavenProject project = null;
-        try {
-            project = embedder.readProject( is );
-        } catch ( ProjectBuildingException e ) {
-            log.error( "Unable to build Maven project from POM", e );
-            throw new RuntimeException( e );
-        } catch ( MavenEmbedderException e ) {
-            log.error( "Unable to build Maven project from POM", e );
-            throw new RuntimeException( e );
+            fos = new FileOutputStream(file);
+            IOUtils.write(string,
+                          fos);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         } finally {
-            try {
-                is.close();
-            } catch ( IOException ioe ) {
-                //Swallow
+            if (fos != null) {
+                try {
+                    fos.flush();
+                    fos.close();
+                } catch (IOException e) {
+                    log.error("Error occurred trying to close a stream",
+                              e);
+                }
             }
         }
-        return project.getDistributionManagement();
     }
 
-    private RemoteRepository getGuvnorM2Repository() {
-        File m2RepoDir = new File( M2_REPO_DIR );
-        if ( !m2RepoDir.exists() ) {
-            log.error( "Repository root does not exist: " + M2_REPO_DIR );
-            throw new IllegalArgumentException( "Repository root does not exist: " + M2_REPO_DIR );
-        }
+    private void deployPom(final GAV gav,
+                           final File pomFile) {
+        //POM Artifact
+        Artifact pomArtifact = new DefaultArtifact(gav.getGroupId(),
+                                                   gav.getArtifactId(),
+                                                   "pom",
+                                                   gav.getVersion());
+        pomArtifact = pomArtifact.setFile(pomFile);
 
-        try {
-            String localRepositoryUrl = m2RepoDir.toURI().toURL().toExternalForm();
-            return new RemoteRepository.Builder( "guvnor-m2-repo",
-                                                 "default",
-                                                 localRepositoryUrl )
-                    .setSnapshotPolicy( new RepositoryPolicy( true,
-                                                              RepositoryPolicy.UPDATE_POLICY_DAILY,
-                                                              RepositoryPolicy.CHECKSUM_POLICY_WARN ) )
-                    .setReleasePolicy( new RepositoryPolicy( true,
-                                                             RepositoryPolicy.UPDATE_POLICY_ALWAYS,
-                                                             RepositoryPolicy.CHECKSUM_POLICY_WARN ) )
-                    .build();
-
-        } catch ( MalformedURLException e ) {
-            log.error( e.getMessage(),
-                       e );
-            throw new RuntimeException( e );
-        }
-    }
-
-    private RemoteRepository getRemoteRepoFromDeployment( final DeploymentRepository repo,
-                                                          final MavenEmbedder embedder ) {
-        RemoteRepository.Builder remoteRepoBuilder = new RemoteRepository.Builder( repo.getId(),
-                                                                                   repo.getLayout(),
-                                                                                   repo
-                                                                                           .getUrl() )
-                .setSnapshotPolicy( new RepositoryPolicy( true,
-                                                          RepositoryPolicy.UPDATE_POLICY_DAILY,
-                                                          RepositoryPolicy.CHECKSUM_POLICY_WARN ) )
-                .setReleasePolicy( new RepositoryPolicy( true,
-                                                         RepositoryPolicy.UPDATE_POLICY_ALWAYS,
-                                                         RepositoryPolicy.CHECKSUM_POLICY_WARN ) );
-
-        Settings settings = MavenSettings.getSettings();
-        Server server = settings.getServer( repo.getId() );
-
-        if ( server != null ) {
-            Authentication authentication = embedder.getMavenSession().getRepositorySession()
-                    .getAuthenticationSelector()
-                    .getAuthentication( remoteRepoBuilder.build() );
-            remoteRepoBuilder.setAuthentication( authentication );
-        }
-
-        return remoteRepoBuilder.build();
+        final Artifact finalPomArtifact = pomArtifact;
+        this.pomRepositories.forEach(artifactRepository -> {
+            artifactRepository.deploy(null,
+                                      finalPomArtifact);
+        });
     }
 
     /**
@@ -530,7 +352,7 @@ public class GuvnorM2Repository {
      * @return an collection of java.io.File with the matching files
      */
     public Collection<File> listFiles() {
-        return listFiles( null );
+        return listFiles(null);
     }
 
     /**
@@ -539,8 +361,9 @@ public class GuvnorM2Repository {
      * to represent a multiple wildcard characters.
      * @return an collection of java.io.File with the matching files
      */
-    public List<File> listFiles( final String filters ) {
-        return listFiles( filters, null );
+    public List<File> listFiles(final String filters) {
+        return listFiles(filters,
+                         null);
     }
 
     /**
@@ -550,450 +373,346 @@ public class GuvnorM2Repository {
      * @param fileFormats file formats to apply when finding files, ie., [ "jar", "kjar" ].
      * @return an collection of java.io.File with the matching files
      */
-    public List<File> listFiles( final String filters, List<String> fileFormats ) {
+    public List<File> listFiles(final String filters,
+                                List<String> fileFormats) {
         final List<String> wildcards = new ArrayList<String>();
         String wildcardPrefix = "";
 
-        if ( filters != null ) {
+        if (filters != null) {
             wildcardPrefix = "*" + filters;
         }
 
-        if ( fileFormats == null ) {
+        if (fileFormats == null) {
             fileFormats = new ArrayList<String>();
-            fileFormats.add( "jar" );
-            fileFormats.add( "kjar" );
-            fileFormats.add( "pom" );
+            fileFormats.add("jar");
+            fileFormats.add("kjar");
+            fileFormats.add("pom");
         }
 
-        for ( String fileFormat : fileFormats ) {
-            wildcards.add( wildcardPrefix + "*." + fileFormat );
+        for (String fileFormat : fileFormats) {
+            wildcards.add(wildcardPrefix + "*." + fileFormat);
         }
 
-        final List<File> files = new ArrayList<File>( getFiles( wildcards ) );
+        final List<File> files = new ArrayList<File>(getFiles(wildcards));
 
         return files;
     }
 
-    protected Collection<File> getFiles( final List<String> wildcards ) {
-        return FileUtils.listFiles( new File( M2_REPO_DIR ),
-                                    new WildcardFileFilter( wildcards,
-                                                            IOCase.INSENSITIVE ),
-                                    DirectoryFileFilter.DIRECTORY );
+    public List<Artifact> listArtifacts(final String filters,
+                                        List<String> fileFormats) {
+        final List<String> wildcards = new ArrayList<String>();
+        String wildcardPrefix = "";
+
+        if (filters != null) {
+            wildcardPrefix = "*" + filters;
+        }
+
+        if (fileFormats == null) {
+            fileFormats = new ArrayList<String>();
+            fileFormats.add("jar");
+            fileFormats.add("kjar");
+            fileFormats.add("pom");
+        }
+
+        for (String fileFormat : fileFormats) {
+            wildcards.add(wildcardPrefix + "*." + fileFormat);
+        }
+
+        final List<Artifact> files = new ArrayList<>(getArtifacts(wildcards));
+
+        return files;
     }
 
-    public static String getPomText( final String path ) {
-        final File file = new File( M2_REPO_DIR,
-                                    path );
+    protected Collection<File> getFiles(final List<String> wildcards) {
+        return this.repositories.stream()
+                .flatMap(artifactRepository -> artifactRepository.listFiles(wildcards).stream())
+                .collect(Collectors.toList());
+    }
+
+    protected Collection<Artifact> getArtifacts(final List<String> wildcards) {
+        return this.repositories.stream()
+                .flatMap(artifactRepository -> artifactRepository.listArtifacts(wildcards).stream())
+                .collect(Collectors.toList());
+    }
+
+    public static String getPomText(final String path) {
+        final File file = new File(M2_REPO_DIR,
+                                   path);
 
         final String normalizedPath = file.toPath().normalize().toString();
-        if ( isJar( normalizedPath ) || isKJar( normalizedPath ) ) {
-            return loadPomFromJar( file );
-        } else if ( isDeployedPom( normalizedPath ) ) {
-            return loadPom( file );
+        if (isJar(normalizedPath) || isKJar(normalizedPath)) {
+            return loadPomFromJar(file);
+        } else if (isDeployedPom(normalizedPath)) {
+            return loadPom(file);
         } else {
-            throw new RuntimeException( "Not a valid jar, kjar or pom file: " + path );
+            throw new RuntimeException("Not a valid jar, kjar or pom file: " + path);
         }
     }
 
-    private static String loadPomFromJar( final File file ) {
-        InputStream is = null;
-        InputStreamReader isr = null;
+    private static String loadPomFromJar(final File file) {
         try {
-            ZipFile zip = new ZipFile( file );
+            ZipFile zip = new ZipFile(file);
 
-            for ( Enumeration e = zip.entries(); e.hasMoreElements(); ) {
+            for (Enumeration e = zip.entries(); e.hasMoreElements(); ) {
                 ZipEntry entry = (ZipEntry) e.nextElement();
 
-                if ( entry.getName().startsWith( "META-INF/maven" ) && entry.getName().endsWith( "pom.xml" ) ) {
-                    is = zip.getInputStream( entry );
-                    isr = new InputStreamReader( is, "UTF-8" );
-                    StringBuilder sb = new StringBuilder();
-                    for ( int c = isr.read(); c != -1; c = isr.read() ) {
-                        sb.append( (char) c );
-                    }
-                    return sb.toString();
+                if (entry.getName().startsWith("META-INF/maven") && entry.getName().endsWith("pom.xml")) {
+                    return zipEntryToString(zip,
+                                            entry);
                 }
             }
-        } catch ( ZipException e ) {
-            log.error( e.getMessage() );
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
-        } finally {
-            if ( isr != null ) {
-                try {
-                    isr.close();
-                } catch ( IOException e ) {
-                }
-            }
-            if ( is != null ) {
-                try {
-                    is.close();
-                } catch ( IOException e ) {
-                }
-            }
+        } catch (ZipException e) {
+            log.error(e.getMessage());
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
 
         return null;
     }
 
-    private static String loadPom( final File file ) {
-        InputStream is = null;
-        InputStreamReader isr = null;
-        try {
-            is = new FileInputStream( file );
-            isr = new InputStreamReader( is, "UTF-8" );
+    private static String loadPom(final File file) {
+        try (InputStream is = new FileInputStream(file);
+             InputStreamReader isr = new InputStreamReader(is,
+                                                           "UTF-8")) {
             StringBuilder sb = new StringBuilder();
-            for ( int c = isr.read(); c != -1; c = isr.read() ) {
-                sb.append( (char) c );
+            for (int c = isr.read(); c != -1; c = isr.read()) {
+                sb.append((char) c);
             }
             return sb.toString();
-
-        } catch ( FileNotFoundException e ) {
-            log.error( e.getMessage() );
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
-        } finally {
-            if ( isr != null ) {
-                try {
-                    isr.close();
-                } catch ( IOException e ) {
-                }
-            }
-            if ( is != null ) {
-                try {
-                    is.close();
-                } catch ( IOException e ) {
-                }
-            }
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
 
         return null;
     }
 
-    public GAV loadGAVFromJar( final String jarPath ) {
-        File zip = new File( M2_REPO_DIR,
-                             jarPath );
+    public GAV loadGAVFromJar(final String jarPath) {
+        File zip = new File(M2_REPO_DIR,
+                            jarPath);
 
         try {
-            final String pomProperties = loadGAVFromJarInternal( zip );
+            final String pomProperties = loadGAVFromJarInternal(zip);
 
             final Properties props = new Properties();
-            props.load( new StringReader( pomProperties ) );
+            props.load(new StringReader(pomProperties));
 
-            final String groupId = props.getProperty( "groupId" );
-            final String artifactId = props.getProperty( "artifactId" );
-            final String version = props.getProperty( "version" );
+            final String groupId = props.getProperty("groupId");
+            final String artifactId = props.getProperty("artifactId");
+            final String version = props.getProperty("version");
 
-            return new GAV( groupId,
-                            artifactId,
-                            version );
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
+            return new GAV(groupId,
+                           artifactId,
+                           version);
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
 
         return null;
     }
 
-    private String loadGAVFromJarInternal( final File file ) {
-        InputStream is = null;
-        InputStreamReader isr = null;
+    private String loadGAVFromJarInternal(final File file) {
         try {
-            ZipFile zip = new ZipFile( file );
+            ZipFile zip = new ZipFile(file);
 
-            for ( Enumeration e = zip.entries(); e.hasMoreElements(); ) {
+            for (Enumeration e = zip.entries(); e.hasMoreElements(); ) {
                 ZipEntry entry = (ZipEntry) e.nextElement();
 
-                if ( entry.getName().startsWith( "META-INF/maven" ) && entry.getName().endsWith( "pom.properties" ) ) {
-                    is = zip.getInputStream( entry );
-                    isr = new InputStreamReader( is, "UTF-8" );
-                    StringBuilder sb = new StringBuilder();
-                    for ( int c = isr.read(); c != -1; c = isr.read() ) {
-                        sb.append( (char) c );
-                    }
-                    return sb.toString();
+                if (entry.getName().startsWith("META-INF/maven") && entry.getName().endsWith("pom.properties")) {
+                    return zipEntryToString(zip,
+                                            entry);
                 }
             }
-        } catch ( ZipException e ) {
-            log.error( e.getMessage() );
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
-        } finally {
-            if ( isr != null ) {
-                try {
-                    isr.close();
-                } catch ( IOException e ) {
-                }
-            }
-            if ( is != null ) {
-                try {
-                    is.close();
-                } catch ( IOException e ) {
-                }
-            }
+        } catch (ZipException e) {
+            log.error(e.getMessage());
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
 
         return null;
     }
 
-    public static String loadPomFromJar( final InputStream jarInputStream ) {
+    public static String loadPomFromJar(final InputStream jarInputStream) {
         try {
 
-            InputStream is = getInputStreamFromJar( jarInputStream,
-                                                    "META-INF/maven",
-                                                    "pom.xml" );
+            InputStream is = getInputStreamFromJar(jarInputStream,
+                                                   "META-INF/maven",
+                                                   "pom.xml");
             StringBuilder sb = new StringBuilder();
-            for ( int c = is.read(); c != -1; c = is.read() ) {
-                sb.append( (char) c );
+            for (int c = is.read(); c != -1; c = is.read()) {
+                sb.append((char) c);
             }
             return sb.toString();
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
 
         return null;
     }
 
-    public static String loadPomPropertiesFromJar( final InputStream jarInputStream ) {
+    public static String loadPomPropertiesFromJar(final InputStream jarInputStream) {
         try {
 
-            InputStream is = getInputStreamFromJar( jarInputStream,
-                                                    "META-INF/maven",
-                                                    "pom.properties" );
+            InputStream is = getInputStreamFromJar(jarInputStream,
+                                                   "META-INF/maven",
+                                                   "pom.properties");
             StringBuilder sb = new StringBuilder();
-            for ( int c = is.read(); c != -1; c = is.read() ) {
-                sb.append( (char) c );
+            for (int c = is.read(); c != -1; c = is.read()) {
+                sb.append((char) c);
             }
             return sb.toString();
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
 
         return null;
     }
 
-    private static InputStream getInputStreamFromJar( final InputStream jarInputStream,
-                                                      final String prefix,
-                                                      final String suffix ) throws IOException {
-        ZipInputStream zis = new ZipInputStream( jarInputStream );
+    private static InputStream getInputStreamFromJar(final InputStream jarInputStream,
+                                                     final String prefix,
+                                                     final String suffix) throws IOException {
+        ZipInputStream zis = new ZipInputStream(jarInputStream);
         ZipEntry entry;
 
-        while ( ( entry = zis.getNextEntry() ) != null ) {
+        while ((entry = zis.getNextEntry()) != null) {
             final String entryName = entry.getName();
-            if ( entryName.startsWith( prefix ) && entryName.endsWith( suffix ) ) {
-                return new ReaderInputStream( new InputStreamReader( zis,
-                                                                     "UTF-8" ) );
+            if (entryName.startsWith(prefix) && entryName.endsWith(suffix)) {
+                return new ReaderInputStream(new InputStreamReader(zis,
+                                                                   "UTF-8"));
             }
         }
 
-        throw new FileNotFoundException( "Could not find '" + prefix + "/*/" + suffix + "' in the jar." );
+        throw new FileNotFoundException("Could not find '" + prefix + "/*/" + suffix + "' in the jar.");
     }
 
-    private File appendPOMToJar( final String pom,
-                                 final String jarPath,
-                                 final GAV gav ) {
-        File originalJarFile = new File( jarPath );
-        File appendedJarFile = new File( jarPath + ".tmp" );
+    private File appendFileToJar(final String content,
+                                 final String contentPath,
+                                 final String jarPath) {
+        File originalJarFile = new File(jarPath);
+        File appendedJarFile = new File(jarPath + ".tmp");
 
-        try {
-            ZipFile war = new ZipFile( originalJarFile );
-
-            ZipOutputStream append = new ZipOutputStream( new FileOutputStream( appendedJarFile ) );
+        try (ZipFile war = new ZipFile(originalJarFile);
+             ZipOutputStream append = new ZipOutputStream(new FileOutputStream(appendedJarFile))) {
 
             // first, copy contents from existing war
-            Enumeration<? extends ZipEntry> entries = war.entries();
-            while ( entries.hasMoreElements() ) {
-                ZipEntry e = entries.nextElement();
-                append.putNextEntry( e );
-                if ( !e.isDirectory() ) {
-                    IOUtil.copy( war.getInputStream( e ),
-                                 append );
-                }
-                append.closeEntry();
-            }
+            copyEntriesFromExistingWar(war,
+                                       append);
 
             // append pom.xml
-            ZipEntry e = new ZipEntry( getPomXmlPath( gav ) );
-            append.putNextEntry( e );
-            append.write( pom.getBytes() );
+            ZipEntry e = new ZipEntry(contentPath);
+            append.putNextEntry(e);
+            append.write(content.getBytes());
             append.closeEntry();
-
-            // close
-            war.close();
-            append.close();
-        } catch ( ZipException e ) {
-            log.error( e.getMessage() );
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
 
         return appendedJarFile;
     }
 
-    private File appendPomPropertiesToJar( final String pomProperties,
-                                           final String jarPath,
-                                           final GAV gav ) {
-        File originalJarFile = new File( jarPath );
-        File appendedJarFile = new File( jarPath + ".tmp" );
-
-        try {
-            ZipFile war = new ZipFile( originalJarFile );
-
-            ZipOutputStream append = new ZipOutputStream( new FileOutputStream( appendedJarFile ) );
-
-            // first, copy contents from existing war
-            Enumeration<? extends ZipEntry> entries = war.entries();
-            while ( entries.hasMoreElements() ) {
-                ZipEntry e = entries.nextElement();
-                append.putNextEntry( e );
-                if ( !e.isDirectory() ) {
-                    IOUtil.copy( war.getInputStream( e ),
-                                 append );
-                }
-                append.closeEntry();
+    private void copyEntriesFromExistingWar(final ZipFile war,
+                                            final ZipOutputStream append) throws IOException {
+        Enumeration<? extends ZipEntry> entries = war.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry e = entries.nextElement();
+            append.putNextEntry(e);
+            if (!e.isDirectory()) {
+                IOUtil.copy(war.getInputStream(e),
+                            append);
             }
-
-            // append pom.properties
-            ZipEntry e = new ZipEntry( getPomPropertiesPath( gav ) );
-            append.putNextEntry( e );
-            append.write( pomProperties.getBytes() );
             append.closeEntry();
-
-            // close
-            war.close();
-            append.close();
-        } catch ( ZipException e ) {
-            log.error( e.getMessage() );
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
         }
-
-        //originalJarFile.delete();
-        //appendedJarFile.renameTo(originalJarFile);
-        return appendedJarFile;
     }
 
-    protected String toFileName( final GAV gav,
-                                 final String fileName ) {
+    protected String toFileName(final GAV gav,
+                                final String fileName) {
         return gav.getGroupId() + "-" + gav.getArtifactId() + "-" + gav.getVersion() + "-" + Math.random() + "." + fileName;
     }
 
-    public String generatePOM( final GAV gav ) {
+    public String generatePOM(final GAV gav) {
         Model model = new Model();
-        model.setGroupId( gav.getGroupId() );
-        model.setArtifactId( gav.getArtifactId() );
-        model.setVersion( gav.getVersion() );
-        model.setModelVersion( "4.0.0" );
+        model.setGroupId(gav.getGroupId());
+        model.setArtifactId(gav.getArtifactId());
+        model.setVersion(gav.getVersion());
+        model.setModelVersion("4.0.0");
 
         StringWriter stringWriter = new StringWriter();
         try {
-            new MavenXpp3Writer().write( stringWriter,
-                                         model );
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
+            new MavenXpp3Writer().write(stringWriter,
+                                        model);
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
 
         return stringWriter.toString();
     }
 
-    public static String generatePomProperties( final GAV gav ) {
+    public static String generatePomProperties(final GAV gav) {
         StringBuilder sBuilder = new StringBuilder();
-        sBuilder.append( "groupId=" );
-        sBuilder.append( gav.getGroupId() );
-        sBuilder.append( "\n" );
+        sBuilder.append("groupId=");
+        sBuilder.append(gav.getGroupId());
+        sBuilder.append("\n");
 
-        sBuilder.append( "artifactId=" );
-        sBuilder.append( gav.getArtifactId() );
-        sBuilder.append( "\n" );
+        sBuilder.append("artifactId=");
+        sBuilder.append(gav.getArtifactId());
+        sBuilder.append("\n");
 
-        sBuilder.append( "version=" );
-        sBuilder.append( gav.getVersion() );
-        sBuilder.append( "\n" );
+        sBuilder.append("version=");
+        sBuilder.append(gav.getVersion());
+        sBuilder.append("\n");
 
         return sBuilder.toString();
     }
 
-    public String getPomXmlPath( final GAV gav ) {
+    public String getPomXmlPath(final GAV gav) {
         return "META-INF/maven/" + gav.getGroupId() + "/" + gav.getArtifactId() + "/pom.xml";
     }
 
-    public String getPomPropertiesPath( final GAV gav ) {
+    public String getPomPropertiesPath(final GAV gav) {
         return "META-INF/maven/" + gav.getGroupId() + "/" + gav.getArtifactId() + "/pom.properties";
     }
 
-    public String generateParentPOM( final GAV gav ) {
+    public String generateParentPOM(final GAV gav) {
         Model model = new Model();
-        model.setGroupId( gav.getGroupId() );
-        model.setArtifactId( gav.getArtifactId() );
-        model.setVersion( gav.getVersion() );
-        model.setPackaging( "pom" );
-        model.setModelVersion( "4.0.0" );
+        model.setGroupId(gav.getGroupId());
+        model.setArtifactId(gav.getArtifactId());
+        model.setVersion(gav.getVersion());
+        model.setPackaging("pom");
+        model.setModelVersion("4.0.0");
 
         StringWriter stringWriter = new StringWriter();
         try {
-            new MavenXpp3Writer().write( stringWriter,
-                                         model );
-        } catch ( IOException e ) {
-            log.error( e.getMessage() );
+            new MavenXpp3Writer().write(stringWriter,
+                                        model);
+        } catch (IOException e) {
+            log.error(e.getMessage());
         }
 
         return stringWriter.toString();
     }
 
-    /**
-     * Checks whether this Maven repository contains the specified artifact (GAV).
-     *
-     * As opposed to ${code {@link #getArtifactFileFromRepository(GAV)}}, this method will not log any WARNings in case
-     * the artifact is not present (the Aether exception is only logged as TRACE message).
-     *
-     * @param gav artifact GAV, never null
-     * @return true if the this Maven repo contains the specified artifact, otherwise false
-     */
-    public boolean containsArtifact( final GAV gav ) {
-        ArtifactRequest request = createArtifactRequest( gav );
-        try {
-            Aether aether = Aether.getAether();
-            aether.getSystem().resolveArtifact( aether.getSession(),
-                                                request );
-        } catch ( ArtifactResolutionException e ) {
-            log.trace( "Artifact {} not found.", gav, e );
-            return false;
-        }
-        log.trace( "Artifact {} found.", gav );
-        return true;
+    public boolean containsArtifact(final GAV gav) {
+        return this.repositories.stream()
+                .anyMatch(artifactRepository -> artifactRepository.containsArtifact(gav));
     }
 
-    public File getArtifactFileFromRepository( final GAV gav ) {
-        ArtifactRequest request = createArtifactRequest( gav );
-        ArtifactResult result = null;
-        try {
-            result = Aether.getAether().getSystem().resolveArtifact(
-                    Aether.getAether().getSession(),
-                    request );
-        } catch ( ArtifactResolutionException e ) {
-            log.warn( e.getMessage(), e );
-        }
-
-        if ( result == null ) {
-            return null;
-        }
-
-        File artifactFile = null;
-        if ( result.isResolved() && !result.isMissing() ) {
-            artifactFile = result.getArtifact().getFile();
-        }
-
-        return artifactFile;
+    public File getArtifactFileFromRepository(final GAV gav) {
+        final List<File> artifacts = this.repositories
+                .stream()
+                .map(artifactRepository -> artifactRepository.getArtifactFileFromRepository(gav))
+                .filter(artifact -> artifact != null)
+                .collect(Collectors.toList());
+        return artifacts.get(0);
     }
 
-    private ArtifactRequest createArtifactRequest( final GAV gav ) {
-        ArtifactRequest request = new ArtifactRequest();
-        request.addRepository( getGuvnorM2Repository() );
-        DefaultArtifact artifact = new DefaultArtifact( gav.getGroupId(),
-                gav.getArtifactId(),
-                "jar",
-                gav.getVersion() );
-        request.setArtifact( artifact );
-        return request;
+    protected static String zipEntryToString(ZipFile zip,
+                                             ZipEntry entry) throws IOException {
+        final InputStream is = zip.getInputStream(entry);
+        final InputStreamReader isr = new InputStreamReader(is,
+                                                            "UTF-8");
+        StringBuilder sb = new StringBuilder();
+        for (int c = isr.read(); c != -1; c = isr.read()) {
+            sb.append((char) c);
+        }
+        return sb.toString();
     }
-
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 
 import org.drools.compiler.kproject.xml.MinimalPomParser;
 import org.drools.compiler.kproject.xml.PomModel;
+import org.eclipse.aether.artifact.Artifact;
 import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.m2repo.model.JarListPageRequest;
 import org.guvnor.m2repo.model.JarListPageRow;
@@ -50,169 +51,170 @@ public class M2RepoServiceImpl implements M2RepoService,
     private GuvnorM2Repository repository;
 
     @Override
-    public void deployJar( final InputStream is,
-                           final GAV gav ) {
-        repository.deployArtifact( is,
-                                   gav,
-                                   true );
+    public void deployJar(final InputStream is,
+                          final GAV gav) {
+        repository.deployArtifact(is,
+                                  gav,
+                                  true);
     }
 
     @Override
-    public void deployJarInternal( final InputStream is,
-                                   final GAV gav ) {
-        repository.deployArtifact( is,
-                                   gav,
-                                   false );
+    public void deployJarInternal(final InputStream is,
+                                  final GAV gav) {
+        repository.deployArtifact(is,
+                                  gav,
+                                  false);
     }
 
     @Override
-    public void deployPom( final InputStream is,
-                           final GAV gav ) {
-        repository.deployPom( is,
-                              gav );
+    public void deployPom(final InputStream is,
+                          final GAV gav) {
+        repository.deployPom(is,
+                             gav);
     }
 
     @Override
-    public String getPomText( final String path ) {
+    public String getPomText(final String path) {
         checkPathTraversal(path);
-        
-        return GuvnorM2Repository.getPomText( path );
+
+        return GuvnorM2Repository.getPomText(path);
     }
 
     @Override
-    public GAV loadGAVFromJar( final String path ) {
+    public GAV loadGAVFromJar(final String path) {
         checkPathTraversal(path);
-        
-        final GAV gav = repository.loadGAVFromJar( path );
+
+        final GAV gav = repository.loadGAVFromJar(path);
         return gav;
     }
 
     @Override
-    public PageResponse<JarListPageRow> listArtifacts( final JarListPageRequest pageRequest ) {
+    public PageResponse<JarListPageRow> listArtifacts(final JarListPageRequest pageRequest) {
         //Get unsorted files matching filter
         final String filters = pageRequest.getFilters();
         final List<String> fileFormats = pageRequest.getFileFormats();
         final String dataSourceName = pageRequest.getDataSourceName();
         final boolean isAscending = pageRequest.isAscending();
-        final Collection<File> files = repository.listFiles( filters, fileFormats );
+        final Collection<Artifact> files = repository.listArtifacts(filters,
+                                                                    fileFormats);
 
         //Convert files to JarListPageRow
         final List<JarListPageRow> jarPageRowList = new ArrayList<JarListPageRow>();
-        for ( File file : files ) {
+        for (Artifact artifact : files) {
+            final File file = artifact.getFile();
             JarListPageRow jarListPageRow = new JarListPageRow();
-            jarListPageRow.setName( file.getName() );
-            jarListPageRow.setPath( getJarPath( file.getPath(),
-                                                File.separator ) );
-            jarListPageRow.setGav( getGAV( jarListPageRow.getPath() ) );
-            jarListPageRow.setLastModified( new Date( file.lastModified() ) );
-            jarPageRowList.add( jarListPageRow );
+            jarListPageRow.setName(file.getName());
+            jarListPageRow.setPath(getJarPath(file.getPath(),
+                                              File.separator));
+            jarListPageRow.setGav(getGAV(jarListPageRow.getPath()));
+            jarListPageRow.setLastModified(new Date(file.lastModified()));
+            jarListPageRow.setRepositoryName(artifact.getProperty("repository",
+                                                                  "undefined"));
+            jarPageRowList.add(jarListPageRow);
         }
 
         //Sort JarListPageRow entries, if required
-        if ( dataSourceName != null ) {
-            final int order = ( isAscending ? 1 : -1 );
-            if ( dataSourceName.equals( JarListPageRequest.COLUMN_NAME ) ) {
-                Collections.sort( jarPageRowList,
-                                  new Comparator<JarListPageRow>() {
-                                      @Override
-                                      public int compare( final JarListPageRow o1,
-                                                          final JarListPageRow o2 ) {
-                                          return o1.getName().compareTo( o2.getName() ) * order;
-                                      }
-                                  } );
-
-            } else if ( dataSourceName.equals( JarListPageRequest.COLUMN_PATH ) ) {
-                Collections.sort( jarPageRowList,
-                                  new Comparator<JarListPageRow>() {
-                                      @Override
-                                      public int compare( final JarListPageRow o1,
-                                                          final JarListPageRow o2 ) {
-                                          return o1.getPath().compareTo( o2.getPath() ) * order;
-                                      }
-                                  } );
-
-            } else if ( dataSourceName.equals( JarListPageRequest.COLUMN_GAV ) ) {
-                Collections.sort( jarPageRowList,
-                                  new Comparator<JarListPageRow>() {
-                                      @Override
-                                      public int compare( final JarListPageRow o1,
-                                                          final JarListPageRow o2 ) {
-                                          final GAV gav1 = o1.getGav();
-                                          final GAV gav2 = o2.getGav();
-                                          return gav1.toString().compareToIgnoreCase( gav2.toString() ) * order;
-                                      }
-                                  } );
-
-            } else if ( dataSourceName.equals( JarListPageRequest.COLUMN_LAST_MODIFIED ) ) {
-                Collections.sort( jarPageRowList,
-                                  new Comparator<JarListPageRow>() {
-                                      @Override
-                                      public int compare( final JarListPageRow o1,
-                                                          final JarListPageRow o2 ) {
-                                          final Long ft1 = o1.getLastModified().getTime();
-                                          final Long ft2 = o2.getLastModified().getTime();
-                                          return ft1.compareTo( ft2 ) * order;
-                                      }
-                                  } );
+        if (dataSourceName != null) {
+            final int order = (isAscending ? 1 : -1);
+            if (dataSourceName.equals(JarListPageRequest.COLUMN_NAME)) {
+                Collections.sort(jarPageRowList,
+                                 new Comparator<JarListPageRow>() {
+                                     @Override
+                                     public int compare(final JarListPageRow o1,
+                                                        final JarListPageRow o2) {
+                                         return o1.getName().compareTo(o2.getName()) * order;
+                                     }
+                                 });
+            } else if (dataSourceName.equals(JarListPageRequest.COLUMN_PATH)) {
+                Collections.sort(jarPageRowList,
+                                 new Comparator<JarListPageRow>() {
+                                     @Override
+                                     public int compare(final JarListPageRow o1,
+                                                        final JarListPageRow o2) {
+                                         return o1.getPath().compareTo(o2.getPath()) * order;
+                                     }
+                                 });
+            } else if (dataSourceName.equals(JarListPageRequest.COLUMN_GAV)) {
+                Collections.sort(jarPageRowList,
+                                 new Comparator<JarListPageRow>() {
+                                     @Override
+                                     public int compare(final JarListPageRow o1,
+                                                        final JarListPageRow o2) {
+                                         final GAV gav1 = o1.getGav();
+                                         final GAV gav2 = o2.getGav();
+                                         return gav1.toString().compareToIgnoreCase(gav2.toString()) * order;
+                                     }
+                                 });
+            } else if (dataSourceName.equals(JarListPageRequest.COLUMN_LAST_MODIFIED)) {
+                Collections.sort(jarPageRowList,
+                                 new Comparator<JarListPageRow>() {
+                                     @Override
+                                     public int compare(final JarListPageRow o1,
+                                                        final JarListPageRow o2) {
+                                         final Long ft1 = o1.getLastModified().getTime();
+                                         final Long ft2 = o2.getLastModified().getTime();
+                                         return ft1.compareTo(ft2) * order;
+                                     }
+                                 });
             }
         }
 
         //Copy request "page" of entries to response
         final Integer pageSize = pageRequest.getPageSize();
         final int startRowIndex = pageRequest.getStartRowIndex();
-        final int endRowIndex = Math.min( jarPageRowList.size(), ( pageSize == null ? jarPageRowList.size() : startRowIndex + pageSize ) );
+        final int endRowIndex = Math.min(jarPageRowList.size(),
+                                         (pageSize == null ? jarPageRowList.size() : startRowIndex + pageSize));
         final List<JarListPageRow> responsePageRowList = new ArrayList<JarListPageRow>();
-        if ( startRowIndex < jarPageRowList.size() ) {
+        if (startRowIndex < jarPageRowList.size()) {
             int i = startRowIndex;
-            while ( i < endRowIndex && i < jarPageRowList.size() ) {
-                responsePageRowList.add( jarPageRowList.get( i ) );
+            while (i < endRowIndex && i < jarPageRowList.size()) {
+                responsePageRowList.add(jarPageRowList.get(i));
                 i++;
             }
         }
 
         final PageResponse<JarListPageRow> response = new PageResponse<JarListPageRow>();
-        response.setPageRowList( responsePageRowList );
-        response.setStartRowIndex( pageRequest.getStartRowIndex() );
-        response.setTotalRowSize( files.size() );
-        response.setTotalRowSizeExact( true );
+        response.setPageRowList(responsePageRowList);
+        response.setStartRowIndex(pageRequest.getStartRowIndex());
+        response.setTotalRowSize(files.size());
+        response.setTotalRowSizeExact(true);
 
         return response;
     }
 
     // The file separator is provided as a parameter so that we can test for correct JAR path creation on both
     // Windows and Linux based Operating Systems in Unit tests running on either platform. See JarPathTest.
-    String getJarPath( final String path,
-                       final String separator ) {
+    String getJarPath(final String path,
+                      final String separator) {
         //Strip "Repository" prefix
-        String jarPath = path.substring( GuvnorM2Repository.M2_REPO_DIR.length() + 1 );
+        String jarPath = path.substring(GuvnorM2Repository.M2_REPO_DIR.length() + 1);
         //Replace OS-dependent file separators with HTTP path separators
-        jarPath = jarPath.replaceAll( "\\" + separator,
-                                      "/" );
+        jarPath = jarPath.replaceAll("\\" + separator,
+                                     "/");
         return jarPath;
     }
 
-    GAV getGAV( final String path ) {
+    GAV getGAV(final String path) {
         GAV gav = null;
         InputStream is = null;
         try {
-            final String pom = getPomText( path );
-            is = new ByteArrayInputStream( pom.getBytes( Charset.forName( "UTF-8" ) ) );
-            final PomModel model = MinimalPomParser.parse( path,
-                                                           is );
-            gav = new GAV( model.getReleaseId().getGroupId(),
-                           model.getReleaseId().getArtifactId(),
-                           model.getReleaseId().getVersion() );
-
-        } catch ( RuntimeException rte ) {
+            final String pom = getPomText(path);
+            is = new ByteArrayInputStream(pom.getBytes(Charset.forName("UTF-8")));
+            final PomModel model = MinimalPomParser.parse(path,
+                                                          is);
+            gav = new GAV(model.getReleaseId().getGroupId(),
+                          model.getReleaseId().getArtifactId(),
+                          model.getReleaseId().getVersion());
+        } catch (RuntimeException rte) {
             //RuntimeException is thrown by MinimalPomParser for any Exception..
-            gav = new GAV( "<undetermined>",
-                           "<undetermined>",
-                           "<undetermined>" );
+            gav = new GAV("<undetermined>",
+                          "<undetermined>",
+                          "<undetermined>");
         } finally {
-            if ( is != null ) {
+            if (is != null) {
                 try {
                     is.close();
-                } catch ( IOException ioe ) {
+                } catch (IOException ioe) {
                     //Swallow
                 }
             }
@@ -226,31 +228,28 @@ public class M2RepoServiceImpl implements M2RepoService,
      * @return String
      */
     @Override
-    public String getRepositoryURL( final String baseURL ) {
-        if ( baseURL == null || baseURL.isEmpty() ) {
+    public String getRepositoryURL(final String baseURL) {
+        if (baseURL == null || baseURL.isEmpty()) {
             return repository.getRepositoryURL();
         } else {
-            if ( baseURL.endsWith( "/" ) ) {
+            if (baseURL.endsWith("/")) {
                 return baseURL + "maven2/";
             } else {
                 return baseURL + "/maven2/";
             }
         }
     }
-    
+
     /**
      * Asserts that the path does not cause traversal.
-     * 
-     * @param path
-     *            the path to check, must not be null.
+     * @param path the path to check, must not be null.
      */
-    private void checkPathTraversal( String path ) {
+    private void checkPathTraversal(String path) {
         // There's no more decoding / unescaping happening on the String beyond 
         // this point so we don't have to check for %u002e, %252e, etc., as these 
         // paths would result in a FileNotFoundException anyway.
-        if ( path.contains( ".." ) ) {
-            throw new RuntimeException( "Invalid path provided!" );
+        if (path.contains("..")) {
+            throw new RuntimeException("Invalid path provided!");
         }
     }
-
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepository.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server.repositories;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.List;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.guvnor.common.services.project.model.GAV;
+
+public interface ArtifactRepository {
+
+    String getName();
+
+    Collection<File> listFiles(final List<String> wildcards);
+
+    Collection<Artifact> listArtifacts(final List<String> wildcards);
+
+    void deploy(String pom,
+                Artifact... artifacts);
+
+    void delete(final GAV gav);
+
+    /**
+     * Checks whether this Maven repository contains the specified artifact (GAV).
+     * <p>
+     * As opposed to ${code {@link #getArtifactFileFromRepository(GAV)}}, this method will not log any WARNings in case
+     * the artifact is not present (the Aether exception is only logged as TRACE message).
+     * @param gav artifact GAV, never null
+     * @return true if the this Maven repo contains the specified artifact, otherwise false
+     */
+    boolean containsArtifact(final GAV gav);
+
+    File getArtifactFileFromRepository(final GAV gav);
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/DistributionManagementArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/DistributionManagementArtifactRepository.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server.repositories;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.maven.model.DeploymentRepository;
+import org.apache.maven.model.DistributionManagement;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.settings.Server;
+import org.apache.maven.settings.Settings;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.deployment.DeployRequest;
+import org.eclipse.aether.deployment.DeploymentException;
+import org.eclipse.aether.repository.Authentication;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.guvnor.common.services.project.model.GAV;
+import org.kie.scanner.Aether;
+import org.kie.scanner.embedder.MavenEmbedder;
+import org.kie.scanner.embedder.MavenEmbedderException;
+import org.kie.scanner.embedder.MavenProjectLoader;
+import org.kie.scanner.embedder.MavenSettings;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DistributionManagementArtifactRepository implements ArtifactRepository {
+
+    private final String name;
+    private Logger logger = LoggerFactory.getLogger(DistributionManagementArtifactRepository.class);
+
+    public DistributionManagementArtifactRepository(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Collection<File> listFiles(final List<String> wildcards) {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public Collection<Artifact> listArtifacts(final List<String> wildcards) {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public boolean containsArtifact(final GAV gav) {
+        return false;
+    }
+
+    @Override
+    public File getArtifactFileFromRepository(final GAV gav) {
+        return null;
+    }
+
+    @Override
+    public void deploy(final String pom,
+                       final Artifact... artifacts) {
+        try {
+
+            MavenEmbedder embedder = MavenProjectLoader.newMavenEmbedder(false);
+            DistributionManagement distributionManagement = getDistributionManagement(pom,
+                                                                                      embedder);
+
+            if (distributionManagement != null) {
+
+                final boolean isSnapshot = Arrays.stream(artifacts).anyMatch(artifact -> artifact.isSnapshot());
+                DeploymentRepository remoteRepository = null;
+                if (isSnapshot) {
+                    remoteRepository = distributionManagement.getSnapshotRepository();
+
+                    //Maven documentation states use of the regular repository if the SNAPSHOT repository is undefined
+                    //See https://maven.apache.org/pom.html#Repository and https://bugzilla.redhat.com/show_bug.cgi?id=1129573
+                    if (remoteRepository == null) {
+                        remoteRepository = distributionManagement.getRepository();
+                    }
+                } else {
+                    remoteRepository = distributionManagement.getRepository();
+                }
+
+                //If the user has configured a distribution management module in the pom then we will attempt to deploy there.
+                //If credentials are required those credentials must be provisioned in the user's settings.xml file
+                if (remoteRepository != null) {
+                    DeployRequest remoteRequest = new DeployRequest();
+
+                    for (Artifact artifact : artifacts) {
+                        remoteRequest.addArtifact(artifact);
+                    }
+
+                    remoteRequest.setRepository(getRemoteRepoFromDeployment(remoteRepository,
+                                                                            embedder));
+
+                    Aether.getAether().getSystem().deploy(Aether.getAether().getSession(),
+                                                          remoteRequest);
+                }
+            }
+        } catch (DeploymentException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private DistributionManagement getDistributionManagement(final String pomXML,
+                                                             final MavenEmbedder embedder) {
+        final InputStream is = new ByteArrayInputStream(pomXML.getBytes(Charset.forName("UTF-8")));
+        MavenProject project = null;
+        try {
+            project = embedder.readProject(is);
+        } catch (ProjectBuildingException e) {
+            logger.error("Unable to build Maven project from POM",
+                         e);
+            throw new RuntimeException(e);
+        } catch (MavenEmbedderException e) {
+            logger.error("Unable to build Maven project from POM",
+                         e);
+            throw new RuntimeException(e);
+        } finally {
+            try {
+                is.close();
+            } catch (IOException ioe) {
+                //Swallow
+            }
+        }
+        return project.getDistributionManagement();
+    }
+
+    private RemoteRepository getRemoteRepoFromDeployment(final DeploymentRepository repo,
+                                                         final MavenEmbedder embedder) {
+        RemoteRepository.Builder remoteRepoBuilder = new RemoteRepository.Builder(repo.getId(),
+                                                                                  repo.getLayout(),
+                                                                                  repo
+                                                                                          .getUrl())
+                .setSnapshotPolicy(new RepositoryPolicy(true,
+                                                        RepositoryPolicy.UPDATE_POLICY_DAILY,
+                                                        RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                .setReleasePolicy(new RepositoryPolicy(true,
+                                                       RepositoryPolicy.UPDATE_POLICY_ALWAYS,
+                                                       RepositoryPolicy.CHECKSUM_POLICY_WARN));
+
+        Settings settings = MavenSettings.getSettings();
+        Server server = settings.getServer(repo.getId());
+
+        if (server != null) {
+            Authentication authentication = embedder.getMavenSession().getRepositorySession()
+                    .getAuthenticationSelector()
+                    .getAuthentication(remoteRepoBuilder.build());
+            remoteRepoBuilder.setAuthentication(authentication);
+        }
+
+        return remoteRepoBuilder.build();
+    }
+
+    @Override
+    public void delete(final GAV gav) {
+
+    }
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/FileSystemArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/FileSystemArtifactRepository.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server.repositories;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOCase;
+import org.apache.commons.io.filefilter.DirectoryFileFilter;
+import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.deployment.DeployRequest;
+import org.eclipse.aether.deployment.DeploymentException;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.m2repo.backend.server.ArtifactImpl;
+import org.kie.scanner.Aether;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.uberfire.apache.commons.io.FilenameUtils;
+
+public class FileSystemArtifactRepository implements ArtifactRepository {
+
+    private final String name;
+    private Logger logger = LoggerFactory.getLogger(FileSystemArtifactRepository.class);
+
+    private RemoteRepository repository;
+    private String repositoryDirectory;
+
+    public FileSystemArtifactRepository(final String name,
+                                        final String dir) {
+        this.name = name;
+        final String m2RepoDir = FilenameUtils.normalize(dir.trim() + File.separatorChar);
+        logger.info("Maven Repository root set to: " + m2RepoDir);
+
+        //Ensure repository root has been created
+        final File root = new File(m2RepoDir);
+        if (!root.exists()) {
+            logger.info("Creating Maven Repository root: " + m2RepoDir);
+            root.mkdirs();
+        }
+        this.repositoryDirectory = dir;
+        this.repository = this.createRepository(dir);
+        Aether.getAether().getRepositories().add(this.getRepository());
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public Collection<File> listFiles(final List<String> wildcards) {
+        return FileUtils.listFiles(new File(this.getRepositoryDirectory()),
+                                   new WildcardFileFilter(wildcards,
+                                                          IOCase.INSENSITIVE),
+                                   DirectoryFileFilter.DIRECTORY);
+    }
+
+    @Override
+    public Collection<Artifact> listArtifacts(final List<String> wildcards) {
+        final Collection<File> files = this.listFiles(wildcards);
+
+        return files.stream().map(file -> {
+            final HashMap<String, String> map = new HashMap<String, String>();
+            map.put("repository",
+                    this.getName());
+            final ArtifactImpl artifact = new ArtifactImpl(file);
+            artifact.setProperties(map);
+            return artifact;
+        }).collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean containsArtifact(final GAV gav) {
+        ArtifactRequest request = createArtifactRequest(gav);
+        try {
+            Aether aether = Aether.getAether();
+            aether.getSystem().resolveArtifact(aether.getSession(),
+                                               request);
+        } catch (ArtifactResolutionException e) {
+            logger.trace("Artifact {} not found.",
+                         gav,
+                         e);
+            return false;
+        }
+        logger.trace("Artifact {} found.",
+                     gav);
+        return true;
+    }
+
+    @Override
+    public File getArtifactFileFromRepository(final GAV gav) {
+        ArtifactRequest request = createArtifactRequest(gav);
+        ArtifactResult result = null;
+        try {
+            result = Aether.getAether().getSystem().resolveArtifact(
+                    Aether.getAether().getSession(),
+                    request);
+        } catch (ArtifactResolutionException e) {
+            logger.warn(e.getMessage(),
+                        e);
+        }
+
+        if (result == null) {
+            return null;
+        }
+
+        File artifactFile = null;
+        if (result.isResolved() && !result.isMissing()) {
+            artifactFile = result.getArtifact().getFile();
+        }
+
+        return artifactFile;
+    }
+
+    @Override
+    public void deploy(final String pom,
+                       final Artifact... artifacts) {
+        try {
+            final DeployRequest deployRequest = new DeployRequest();
+
+            for (Artifact artifact : artifacts) {
+                deployRequest.addArtifact(artifact);
+            }
+
+            deployRequest.setRepository(getRepository());
+
+            Aether.getAether().getSystem().deploy(Aether.getAether().getSession(),
+                                                  deployRequest);
+        } catch (DeploymentException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void delete(final GAV gav) {
+
+    }
+
+    private ArtifactRequest createArtifactRequest(final GAV gav) {
+        ArtifactRequest request = new ArtifactRequest();
+        request.addRepository(this.getRepository());
+        DefaultArtifact artifact = new DefaultArtifact(gav.getGroupId(),
+                                                       gav.getArtifactId(),
+                                                       "jar",
+                                                       gav.getVersion());
+        request.setArtifact(artifact);
+        return request;
+    }
+
+    protected RemoteRepository getRepository() {
+        return this.repository;
+    }
+
+    private RemoteRepository createRepository(final String dir) {
+        File m2RepoDir = new File(dir);
+        if (!m2RepoDir.exists()) {
+            logger.error("Repository root does not exist: " + dir);
+            throw new IllegalArgumentException("Repository root does not exist: " + dir);
+        }
+
+        try {
+            String localRepositoryUrl = m2RepoDir.toURI().toURL().toExternalForm();
+            return new RemoteRepository.Builder("guvnor-m2-repo",
+                                                "default",
+                                                localRepositoryUrl)
+                    .setSnapshotPolicy(new RepositoryPolicy(true,
+                                                            RepositoryPolicy.UPDATE_POLICY_DAILY,
+                                                            RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                    .setReleasePolicy(new RepositoryPolicy(true,
+                                                           RepositoryPolicy.UPDATE_POLICY_ALWAYS,
+                                                           RepositoryPolicy.CHECKSUM_POLICY_WARN))
+                    .build();
+        } catch (MalformedURLException e) {
+            logger.error(e.getMessage(),
+                         e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getRepositoryDirectory() {
+        return repositoryDirectory;
+    }
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/LocalArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/LocalArtifactRepository.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server.repositories;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.installation.InstallRequest;
+import org.eclipse.aether.installation.InstallationException;
+import org.guvnor.common.services.project.model.GAV;
+import org.kie.scanner.Aether;
+
+public class LocalArtifactRepository implements ArtifactRepository {
+
+    private final String name;
+
+    public LocalArtifactRepository(final String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Collection<File> listFiles(final List<String> wildcards) {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public Collection<Artifact> listArtifacts(final List<String> wildcards) {
+        return Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public boolean containsArtifact(final GAV gav) {
+        return false;
+    }
+
+    @Override
+    public File getArtifactFileFromRepository(final GAV gav) {
+        return null;
+    }
+
+    @Override
+    public void deploy(final String pom,
+                       Artifact... artifacts) {
+
+        try {
+            final InstallRequest installRequest = new InstallRequest();
+            for (Artifact artifact : artifacts) {
+                installRequest
+                        .addArtifact(artifact);
+            }
+            Aether.getAether().getSystem().install(Aether.getAether().getSession(),
+                                                   installRequest);
+        } catch (InstallationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void delete(final GAV gav) {
+
+    }
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
@@ -26,6 +26,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.enterprise.inject.Instance;
+
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.deployment.DeployRequest;
@@ -35,6 +37,7 @@ import org.eclipse.aether.installation.InstallationException;
 import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.m2repo.preferences.ArtifactRepositoryPreference;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.AfterClass;
@@ -80,7 +83,7 @@ public class GuvnorM2RepositoryTest {
     private GuvnorM2Repository repo;
     private RepositorySystem repositorySystem = mock( RepositorySystem.class );
     private RepositorySystemSession repositorySystemSession = mock( RepositorySystemSession.class );
-    
+
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
@@ -118,8 +121,9 @@ public class GuvnorM2RepositoryTest {
     @Before
     public void setup() throws Exception {
         log.info( "Deleting existing Repositories instance.." );
-
-        repo = new GuvnorM2Repository();
+        ArtifactRepositoryPreference pref = mock(ArtifactRepositoryPreference.class);
+        when(pref.getDefaultM2RepoDir()).thenReturn( "repositories/kie" );
+        repo = new GuvnorM2Repository(pref);
         repo.init();
 
         Aether aether = mock( Aether.class );
@@ -262,15 +266,15 @@ public class GuvnorM2RepositoryTest {
         spiedRepo.listFiles( filter, fileFormats );
         verify( spiedRepo ).getFiles( wildcards );
     }
-    
+
     @Test
     public void testGetPomTextVerifiesPath() {
         GuvnorM2Repository.getPomText( "dir/name.pom" );
         GuvnorM2Repository.getPomText( "dir/name.kjar" );
         GuvnorM2Repository.getPomText( "dir/name.jar" );
-        
+
         exception.expect( RuntimeException.class );
         GuvnorM2Repository.getPomText( "dir/name.foo" );
     }
-    
+
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/JarPathTest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/JarPathTest.java
@@ -16,32 +16,23 @@
 
 package org.guvnor.m2repo.backend.server;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.UnsupportedEncodingException;
-import java.util.Collection;
+import javax.enterprise.inject.Instance;
 
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.FileItemHeaders;
 import org.guvnor.common.services.project.model.GAV;
-import org.guvnor.m2repo.backend.server.helpers.FormData;
-import org.guvnor.m2repo.backend.server.helpers.HttpPostHelper;
-import org.junit.After;
+import org.guvnor.m2repo.preferences.ArtifactRepositoryPreference;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
 
 public class JarPathTest {
 
     @Before
     public void setupGuvnorM2Repository() {
-        new GuvnorM2Repository().init();
+        ArtifactRepositoryPreference pref = mock(ArtifactRepositoryPreference.class);
+        when(pref.getDefaultM2RepoDir()).thenReturn( "repositories/kie" );
+        new GuvnorM2Repository(pref).init();
     }
 
     @Test

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/pom.xml
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/pom.xml
@@ -68,6 +68,16 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-preferences-ui-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-client</artifactId>
     </dependency>
 
@@ -84,6 +94,11 @@
     <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
     </dependency>
 
     <dependency>

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/M2RepoEditorEntryPoint.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/M2RepoEditorEntryPoint.java
@@ -18,8 +18,10 @@ package org.guvnor.m2repo.client;
 import org.guvnor.m2repo.client.resources.M2RepoEditorResources;
 import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
+import org.jboss.errai.ui.shared.api.annotations.Bundle;
 
 @EntryPoint
+@Bundle( "resources/i18n/M2Constants.properties" )
 public class M2RepoEditorEntryPoint {
 
     @AfterInitialization

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/resources/i18n/M2Constants.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/resources/i18n/M2Constants.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.client.resources.i18n;
+
+import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
+
+public class M2Constants {
+
+    @TranslationKey(defaultValue = "Artifact Repository")
+    public static final String ArtifactRepositoryPreference_Label = "ArtifactRepositoryPreference.Label";
+
+    @TranslationKey(defaultValue = "M2 repository directory")
+    public static final String ArtifactRepositoryPreference_DefaultM2RepoDir = "ArtifactRepositoryPreference.DefaultM2RepoDir";
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/resources/i18n/M2RepoEditorConstants.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/resources/i18n/M2RepoEditorConstants.java
@@ -18,6 +18,7 @@ package org.guvnor.m2repo.client.resources.i18n;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.i18n.client.Messages;
+import org.jboss.errai.ui.shared.api.annotations.TranslationKey;
 
 /**
  * EnumEditor I18N constants
@@ -85,7 +86,7 @@ public interface M2RepoEditorConstants
     String Date();
 
     String DecimalNumber();
-    
+
     String AreYouSureYouWantToDeleteTheseItems();
 
     String JarDetails();

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/GuvnorM2RepoEditorClient.gwt.xml
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/GuvnorM2RepoEditorClient.gwt.xml
@@ -20,6 +20,8 @@
     "http://www.gwtproject.org/doctype/2.7.0/gwt-module.dtd">
 <module>
 
+  <source path="client"/>
+
   <!-- Inherit the core Web Toolkit stuff. -->
   <inherits name="com.google.gwt.i18n.I18N"/>
   <inherits name="com.google.gwt.http.HTTP"/>
@@ -27,7 +29,7 @@
 
   <inherits name='org.gwtbootstrap3.GwtBootstrap3NoTheme'/>
 
-  <inherits name="org.uberfire.UberfireClient"/>
+  <inherits name="org.uberfire.UberfireClientAll"/>
   <inherits name="org.guvnor.m2repo.GuvnorM2RepoEditorAPI"/>
   <inherits name="org.guvnor.common.services.project.GuvnorProjectAPI"/>
 

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/client/resources/i18n/M2Constants.properties
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/client/resources/i18n/M2Constants.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2017 Red Hat, Inc. and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+
+
+ArtifactRepositoryPreference.Label=Artifact Repository
+ArtifactRepositoryPreference.DefaultM2RepoDir=M2 repository directory


### PR DESCRIPTION
Add some classes to help GuvnorM2Repository add more repositories easily. 

An ArtifactRepository interface was created son every new kind of repository should extend it to be part of GuvnorM2Repositories. 

Right now the behaviour remains the same but this let us add new FileSystem repositories or remote repositories just adding a new instance of them to GuvnorM2Repository.

It also has a Preference class so we can configure it from Workbench.