### PR TITLE
Ignore Guvnor ALA failing tests in guvnor-ala-distribution

### DIFF
--- a/guvnor-ala/guvnor-ala-distribution/src/test/java/org/guvnor/ala/services/tests/PipelineEndpointsTestIT.java
+++ b/guvnor-ala/guvnor-ala-distribution/src/test/java/org/guvnor/ala/services/tests/PipelineEndpointsTestIT.java
@@ -24,14 +24,15 @@ import java.util.List;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
+
 import org.apache.commons.io.FileUtils;
 import org.guvnor.ala.build.maven.config.impl.MavenBuildConfigImpl;
 import org.guvnor.ala.build.maven.config.impl.MavenBuildExecConfigImpl;
 import org.guvnor.ala.build.maven.config.impl.MavenProjectConfigImpl;
 import org.guvnor.ala.config.Config;
+import org.guvnor.ala.docker.config.DockerProviderConfig;
 import org.guvnor.ala.docker.config.impl.ContextAwareDockerProvisioningConfig;
 import org.guvnor.ala.docker.config.impl.ContextAwareDockerRuntimeExecConfig;
-import org.guvnor.ala.docker.config.DockerProviderConfig;
 import org.guvnor.ala.docker.config.impl.DockerBuildConfigImpl;
 import org.guvnor.ala.docker.config.impl.DockerProviderConfigImpl;
 import org.guvnor.ala.docker.model.DockerProvider;
@@ -47,10 +48,9 @@ import org.guvnor.ala.source.git.config.impl.GitConfigImpl;
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.Ignore;
+
+import static org.junit.Assert.*;
 
 public class PipelineEndpointsTestIT {
 
@@ -68,7 +68,7 @@ public class PipelineEndpointsTestIT {
         FileUtils.deleteQuietly( tempPath );
     }
 
-    @Test
+    @Ignore
     public void checkService() {
         Client client = ClientBuilder.newClient();
         WebTarget target = client.target( APP_URL );

--- a/guvnor-ala/guvnor-ala-distribution/src/test/java/org/guvnor/ala/services/tests/RuntimeEndpointsTestIT.java
+++ b/guvnor-ala/guvnor-ala-distribution/src/test/java/org/guvnor/ala/services/tests/RuntimeEndpointsTestIT.java
@@ -19,6 +19,7 @@ package org.guvnor.ala.services.tests;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
+
 import org.guvnor.ala.docker.config.DockerProviderConfig;
 import org.guvnor.ala.docker.config.DockerRuntimeConfig;
 import org.guvnor.ala.docker.config.impl.DockerProviderConfigImpl;
@@ -30,9 +31,8 @@ import org.guvnor.ala.services.api.RuntimeProvisioningService;
 import org.guvnor.ala.services.api.itemlist.ProviderList;
 import org.guvnor.ala.services.api.itemlist.ProviderTypeList;
 import org.guvnor.ala.services.api.itemlist.RuntimeList;
-
 import org.jboss.resteasy.client.jaxrs.ResteasyWebTarget;
-import org.junit.Test;
+import org.junit.Ignore;
 
 import static org.junit.Assert.*;
 
@@ -40,7 +40,7 @@ public class RuntimeEndpointsTestIT {
 
     private final String APP_URL = "http://localhost:8080/api/";
 
-    @Test
+    @Ignore
     public void checkService() {
         Client client = ClientBuilder.newClient();
         WebTarget target = client.target( APP_URL );


### PR DESCRIPTION
@manstis @porcelli @krisv @mbiarnes 

This is the PR for the two failing tests that are failng in guvnor-ala-distribution. As discussed by email the "best" option is to ignore then since nobody will use the guvnor-ala-distribution stuff at least until the 7.1 and let the 7.0.0.Final be.

This is the 7.0.x counter part for the https://github.com/kiegroup/guvnor/pull/452

