### PR TITLE
[UF-506]: WorkspaceScoped beans

### DIFF
--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/preferences/ArtifactRepositoryPreference.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/preferences/ArtifactRepositoryPreference.java
@@ -24,20 +24,68 @@ import org.uberfire.preferences.shared.bean.BasePreference;
 @WorkbenchPreference(identifier = "ArtifactRepositoryPreference", bundleKey = "ArtifactRepositoryPreference.Label")
 public class ArtifactRepositoryPreference implements BasePreference<ArtifactRepositoryPreference> {
 
-    @Property(bundleKey = "ArtifactRepositoryPreference.DefaultM2RepoDir")
-    private String defaultM2RepoDir;
+    @Property(bundleKey = "ArtifactRepositoryPreference.GlobalM2RepoDir")
+    private String globalM2RepoDir;
+
+    @Property(bundleKey = "ArtifactRepositoryPreference.GlobalM2RepoDirEnabled")
+    private boolean globalM2RepoDirEnabled;
+
+    @Property(bundleKey = "ArtifactRepositoryPreference.WorkspaceM2RepoDir")
+    private String workspaceM2RepoDir;
+
+    @Property(bundleKey = "ArtifactRepositoryPreference.WorkspaceM2RepoDirEnabled")
+    private boolean workspaceM2RepoDirEnabled;
+
+    @Property(bundleKey = "ArtifactRepositoryPreference.DistributionManagementM2RepoDirEnabled")
+    private boolean distributionManagementM2RepoDirEnabled;
 
     @Override
     public ArtifactRepositoryPreference defaultValue(final ArtifactRepositoryPreference defaultValue) {
-        defaultValue.defaultM2RepoDir = "repositories/kie";
+        defaultValue.globalM2RepoDir = "repositories/kie/global";
+        defaultValue.workspaceM2RepoDir = "repositories/kie/workspaces";
+        defaultValue.globalM2RepoDirEnabled = true;
+        defaultValue.workspaceM2RepoDirEnabled = false;
+        defaultValue.distributionManagementM2RepoDirEnabled = true;
         return defaultValue;
     }
 
-    public String getDefaultM2RepoDir() {
-        return defaultM2RepoDir;
+    public String getGlobalM2RepoDir() {
+        return globalM2RepoDir;
     }
 
-    public void setDefaultM2RepoDir(final String defaultM2RepoDir) {
-        this.defaultM2RepoDir = defaultM2RepoDir.trim();
+    public void setGlobalM2RepoDir(final String globalM2RepoDir) {
+        this.globalM2RepoDir = globalM2RepoDir.trim();
+    }
+
+    public String getWorkspaceM2RepoDir() {
+        return workspaceM2RepoDir;
+    }
+
+    public void setWorkspaceM2RepoDir(String workspaceM2RepoDir) {
+        this.workspaceM2RepoDir = workspaceM2RepoDir;
+    }
+
+    public boolean isGlobalM2RepoDirEnabled() {
+        return globalM2RepoDirEnabled;
+    }
+
+    public void setGlobalM2RepoDirEnabled(boolean globalM2RepoDirEnabled) {
+        this.globalM2RepoDirEnabled = globalM2RepoDirEnabled;
+    }
+
+    public boolean isWorkspaceM2RepoDirEnabled() {
+        return workspaceM2RepoDirEnabled;
+    }
+
+    public void setWorkspaceM2RepoDirEnabled(boolean workspaceM2RepoDirEnabled) {
+        this.workspaceM2RepoDirEnabled = workspaceM2RepoDirEnabled;
+    }
+
+    public boolean isDistributionManagementM2RepoDirEnabled() {
+        return distributionManagementM2RepoDirEnabled;
+    }
+
+    public void setDistributionManagementM2RepoDirEnabled(boolean distributionManagementM2RepoDirEnabled) {
+        this.distributionManagementM2RepoDirEnabled = distributionManagementM2RepoDirEnabled;
     }
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/pom.xml
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/pom.xml
@@ -111,6 +111,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-cdi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-maven-integration</artifactId>
     </dependency>
 
@@ -122,6 +127,11 @@
     <dependency>
       <groupId>org.jboss.errai</groupId>
       <artifactId>errai-bus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-security-server</artifactId>
     </dependency>
 
     <dependency>

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
@@ -34,6 +34,7 @@ import org.appformer.maven.support.MinimalPomParser;
 import org.appformer.maven.support.PomModel;
 import org.eclipse.aether.artifact.Artifact;
 import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryFactory;
 import org.guvnor.m2repo.model.JarListPageRequest;
 import org.guvnor.m2repo.model.JarListPageRow;
 import org.guvnor.m2repo.service.M2RepoService;
@@ -47,8 +48,15 @@ import org.uberfire.paging.PageResponse;
 public class M2RepoServiceImpl implements M2RepoService,
                                           ExtendedM2RepoService {
 
-    @Inject
     private GuvnorM2Repository repository;
+
+    public M2RepoServiceImpl() {
+    }
+
+    @Inject
+    public M2RepoServiceImpl(GuvnorM2Repository repository) {
+        this.repository = repository;
+    }
 
     @Override
     public void deployJar(final InputStream is,
@@ -77,7 +85,7 @@ public class M2RepoServiceImpl implements M2RepoService,
     public String getPomText(final String path) {
         checkPathTraversal(path);
 
-        return GuvnorM2Repository.getPomText(path);
+        return repository.getPomText(path);
     }
 
     @Override
@@ -187,7 +195,8 @@ public class M2RepoServiceImpl implements M2RepoService,
     String getJarPath(final String path,
                       final String separator) {
         //Strip "Repository" prefix
-        String jarPath = path.substring(GuvnorM2Repository.M2_REPO_DIR.length() + 1);
+        String pathToDir = repository.getM2RepositoryDir(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME);
+        String jarPath = path.substring(pathToDir.length() + 1);
         //Replace OS-dependent file separators with HTTP path separators
         jarPath = jarPath.replaceAll("\\" + separator,
                                      "/");
@@ -230,7 +239,7 @@ public class M2RepoServiceImpl implements M2RepoService,
     @Override
     public String getRepositoryURL(final String baseURL) {
         if (baseURL == null || baseURL.isEmpty()) {
-            return repository.getRepositoryURL();
+            return repository.getRepositoryURL(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME);
         } else {
             if (baseURL.endsWith("/")) {
                 return baseURL + "maven2/";

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/helpers/HttpPutHelper.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/helpers/HttpPutHelper.java
@@ -36,13 +36,13 @@ import org.slf4j.LoggerFactory;
 
 public class HttpPutHelper {
 
-    private static final Logger log = LoggerFactory.getLogger( HttpPutHelper.class );
+    private static final Logger log = LoggerFactory.getLogger(HttpPutHelper.class);
 
     @Inject
     private GuvnorM2Repository m2RepoService;
 
-    public void handle( final HttpServletRequest request,
-                        final HttpServletResponse response ) throws ServletException, IOException {
+    public void handle(final HttpServletRequest request,
+                       final HttpServletResponse response) throws ServletException, IOException {
 
         final InputStream inputStream = request.getInputStream();
         OutputStream outputStream = null;
@@ -53,70 +53,67 @@ public class HttpPutHelper {
             //Get destination path
             String pathInfo = request.getPathInfo();
 
-            if ( pathInfo == null ) {
-                response.sendError( HttpServletResponse.SC_NOT_FOUND );
+            if (pathInfo == null) {
+                response.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }
 
-            pathInfo = URLDecoder.decode( pathInfo,
-                                          "UTF-8" );
+            pathInfo = URLDecoder.decode(pathInfo,
+                                         "UTF-8");
+
+            String repositoryName = request.getParameter("repository");
 
             //File traversal check:
-            final File mavenRootDir = new File( m2RepoService.getM2RepositoryRootDir() );
+            final File mavenRootDir = new File(m2RepoService.getM2RepositoryRootDir(repositoryName));
             final String canonicalDirPath = mavenRootDir.getCanonicalPath() + File.separator;
-            final String canonicalEntryPath = new File( mavenRootDir,
-                                                        pathInfo ).getCanonicalPath();
-            if ( !canonicalEntryPath.startsWith( canonicalDirPath ) ) {
-                response.sendError( HttpServletResponse.SC_NOT_FOUND );
+            final String canonicalEntryPath = new File(mavenRootDir,
+                                                       pathInfo).getCanonicalPath();
+            if (!canonicalEntryPath.startsWith(canonicalDirPath)) {
+                response.sendError(HttpServletResponse.SC_NOT_FOUND);
                 return;
             }
 
-            pathInfo = canonicalEntryPath.substring( canonicalDirPath.length() );
-            final File file = new File( mavenRootDir,
-                                        pathInfo );
+            pathInfo = canonicalEntryPath.substring(canonicalDirPath.length());
+            final File file = new File(mavenRootDir,
+                                       pathInfo);
 
             //Create new file if it does not already exist and set status code to 201
             //See http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html Section 9.6 PUT
-            if ( !file.exists() ) {
+            if (!file.exists()) {
                 file.getParentFile().mkdirs();
                 file.createNewFile();
                 status = HttpServletResponse.SC_CREATED;
             }
 
-            outputStream = new BufferedOutputStream( new FileOutputStream( file ) );
+            outputStream = new BufferedOutputStream(new FileOutputStream(file));
 
             //Copy input
-            IOUtil.copy( inputStream,
-                         outputStream );
+            IOUtil.copy(inputStream,
+                        outputStream);
 
-            response.setStatus( status );
-
-        } catch ( FileNotFoundException e ) {
-            log.error( e.toString(),
-                       e );
-
-        } catch ( IOException e ) {
-            log.error( e.toString(),
-                       e );
-
+            response.setStatus(status);
+        } catch (FileNotFoundException e) {
+            log.error(e.toString(),
+                      e);
+        } catch (IOException e) {
+            log.error(e.toString(),
+                      e);
         } finally {
-            if ( outputStream != null ) {
+            if (outputStream != null) {
                 try {
                     outputStream.flush();
                     outputStream.close();
-                } catch ( IOException e ) {
+                } catch (IOException e) {
                     //Swallow
                 }
             }
-            if ( inputStream != null ) {
+            if (inputStream != null) {
                 try {
                     inputStream.close();
-                } catch ( IOException e ) {
+                } catch (IOException e) {
                     //Swallow
                 }
             }
         }
-
     }
-
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepository.java
@@ -24,17 +24,49 @@ import java.util.List;
 import org.eclipse.aether.artifact.Artifact;
 import org.guvnor.common.services.project.model.GAV;
 
+/**
+ * Represents an artifact repository. Every repository should implement this interface.
+ */
 public interface ArtifactRepository {
 
+    /**
+     * Returns the name of the repository, an identifier
+     * @return the name
+     */
     String getName();
 
+    /**
+     * Return the root dir of a repository, if it doesn't have one, return null
+     * @return the root dir of a repository.
+     */
+    String getRootDir();
+
+    /**
+     * List repository files filtered by wildcards
+     * @param wildcards the filtering wildcards
+     * @return the files
+     */
     Collection<File> listFiles(final List<String> wildcards);
 
+    /**
+     * List repository artifacts filtered by wildcards
+     * @param wildcards the filtering wildcards
+     * @return the artifacts
+     */
     Collection<Artifact> listArtifacts(final List<String> wildcards);
 
+    /**
+     * Deploy a list of artifact into a repository
+     * @param pom the artifact pom
+     * @param artifacts the list of artifacts
+     */
     void deploy(String pom,
                 Artifact... artifacts);
 
+    /**
+     * Delete an artifact from the repository
+     * @param gav the GAV identifier of the artifact to be deleted
+     */
     void delete(final GAV gav);
 
     /**
@@ -47,5 +79,22 @@ public interface ArtifactRepository {
      */
     boolean containsArtifact(final GAV gav);
 
+    /**
+     * Return an artifact from the repository
+     * @param gav the GAV identifier
+     * @return the artifact found
+     */
     File getArtifactFileFromRepository(final GAV gav);
+
+    /**
+     * Identifies if is a repository that admit artifacts
+     * @return
+     */
+    boolean isRepository();
+
+    /**
+     * Identifies if is a repository that admit pom artifacts
+     * @return
+     */
+    boolean isPomRepository();
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepositoryFactory.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepositoryFactory.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server.repositories;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.guvnor.m2repo.preferences.ArtifactRepositoryPreference;
+import org.uberfire.apache.commons.io.FilenameUtils;
+import org.uberfire.backend.server.cdi.workspace.WorkspaceNameResolver;
+
+@ApplicationScoped
+public class ArtifactRepositoryFactory {
+
+    public static final String LOCAL_M2_REPO_NAME = "local-m2-repo";
+    public static final String GLOBAL_M2_REPO_NAME = "global-m2-repo";
+    public static final String WORKSPACE_M2_REPO_NAME = "workspace-m2-repo";
+    public static final String DISTRIBUTION_MANAGEMENT_REPO_NAME = "distribution-management-repo";
+    public static final String ORG_GUVNOR_M2REPO_DIR_PROPERTY = "org.guvnor.m2repo.dir";
+
+    private ArtifactRepositoryPreference preferences;
+    private WorkspaceNameResolver workspaceNameResolver;
+    private List<ArtifactRepository> repositories;
+
+    public ArtifactRepositoryFactory() {
+    }
+
+    @Inject
+    public ArtifactRepositoryFactory(ArtifactRepositoryPreference preferences,
+                                     WorkspaceNameResolver resolver) {
+        this.preferences = preferences;
+        this.workspaceNameResolver = resolver;
+    }
+
+    @PostConstruct
+    public void initialize() {
+        this.preferences.load();
+        this.repositories = new ArrayList<>();
+
+        this.repositories.add(this.produceLocalRepository());
+        if (this.preferences.isGlobalM2RepoDirEnabled()) {
+            this.repositories.add(this.produceGlobalRepository());
+        }
+        if (this.preferences.isWorkspaceM2RepoDirEnabled()) {
+            this.repositories.add(this.produceWorkspaceRepository());
+        }
+        if (this.preferences.isDistributionManagementM2RepoDirEnabled()) {
+            this.repositories.add(this.produceDistributionManagementRepository());
+        }
+    }
+
+    public LocalArtifactRepository produceLocalRepository() {
+        return new LocalArtifactRepository(LOCAL_M2_REPO_NAME);
+    }
+
+    public FileSystemArtifactRepository produceGlobalRepository() {
+        return new FileSystemArtifactRepository(GLOBAL_M2_REPO_NAME,
+                                                this.getGlobalM2RepoDir());
+    }
+
+    public FileSystemArtifactRepository produceWorkspaceRepository() {
+        String repoDir = getWorkspaceRepoDir();
+        return new FileSystemArtifactRepository(WORKSPACE_M2_REPO_NAME,
+                                                repoDir);
+    }
+
+    public DistributionManagementArtifactRepository produceDistributionManagementRepository() {
+        return new DistributionManagementArtifactRepository(DISTRIBUTION_MANAGEMENT_REPO_NAME);
+    }
+
+    private String getGlobalM2RepoDir() {
+        final String repoRoot = FilenameUtils.separatorsToSystem(preferences.getGlobalM2RepoDir());
+
+        final String meReposDir = System.getProperty(ORG_GUVNOR_M2REPO_DIR_PROPERTY);
+
+        String repoDir;
+        if (meReposDir == null || meReposDir.trim().isEmpty()) {
+            repoDir = repoRoot;
+        } else {
+            repoDir = meReposDir.trim();
+        }
+        return repoDir;
+    }
+
+    private String getWorkspaceRepoDir() {
+        String workspace = this.getWorkspaceName();
+        final String repoRoot = FilenameUtils.separatorsToSystem(preferences.getWorkspaceM2RepoDir());
+        String repoDir;
+        if (repoRoot == null || repoRoot.trim().isEmpty()) {
+            repoDir = this.getGlobalM2RepoDir() + File.separator + "workspaces";
+        } else {
+            repoDir = repoRoot;
+        }
+        return repoDir + File.separator + workspace;
+    }
+
+    private String getWorkspaceName() {
+        return workspaceNameResolver.getWorkspaceName();
+    }
+
+    public List<? extends ArtifactRepository> getRepositories() {
+        return this.repositories.stream().filter(ArtifactRepository::isRepository).collect(Collectors.toList());
+    }
+
+    public List<? extends ArtifactRepository> getPomRepositories() {
+        return this.repositories.stream().filter(ArtifactRepository::isPomRepository).collect(Collectors.toList());
+    }
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/DistributionManagementArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/DistributionManagementArtifactRepository.java
@@ -50,8 +50,11 @@ import org.slf4j.LoggerFactory;
 
 public class DistributionManagementArtifactRepository implements ArtifactRepository {
 
-    private final String name;
+    private String name;
     private Logger logger = LoggerFactory.getLogger(DistributionManagementArtifactRepository.class);
+
+    public DistributionManagementArtifactRepository() {
+    }
 
     public DistributionManagementArtifactRepository(final String name) {
         this.name = name;
@@ -60,6 +63,11 @@ public class DistributionManagementArtifactRepository implements ArtifactReposit
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String getRootDir() {
+        return null;
     }
 
     @Override
@@ -80,6 +88,16 @@ public class DistributionManagementArtifactRepository implements ArtifactReposit
     @Override
     public File getArtifactFileFromRepository(final GAV gav) {
         return null;
+    }
+
+    @Override
+    public boolean isRepository() {
+        return true;
+    }
+
+    @Override
+    public boolean isPomRepository() {
+        return false;
     }
 
     @Override

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/FileSystemArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/FileSystemArtifactRepository.java
@@ -47,11 +47,14 @@ import org.uberfire.apache.commons.io.FilenameUtils;
 
 public class FileSystemArtifactRepository implements ArtifactRepository {
 
-    private final String name;
+    private String name;
     private Logger logger = LoggerFactory.getLogger(FileSystemArtifactRepository.class);
 
     private RemoteRepository repository;
     private String repositoryDirectory;
+
+    public FileSystemArtifactRepository() {
+    }
 
     public FileSystemArtifactRepository(final String name,
                                         final String dir) {
@@ -73,6 +76,11 @@ public class FileSystemArtifactRepository implements ArtifactRepository {
     @Override
     public String getName() {
         return this.name;
+    }
+
+    @Override
+    public String getRootDir() {
+        return this.getRepositoryDirectory();
     }
 
     @Override
@@ -141,6 +149,16 @@ public class FileSystemArtifactRepository implements ArtifactRepository {
     }
 
     @Override
+    public boolean isRepository() {
+        return true;
+    }
+
+    @Override
+    public boolean isPomRepository() {
+        return true;
+    }
+
+    @Override
     public void deploy(final String pom,
                        final Artifact... artifacts) {
         try {
@@ -188,7 +206,7 @@ public class FileSystemArtifactRepository implements ArtifactRepository {
 
         try {
             String localRepositoryUrl = m2RepoDir.toURI().toURL().toExternalForm();
-            return new RemoteRepository.Builder("guvnor-m2-repo",
+            return new RemoteRepository.Builder(this.getName(),
                                                 "default",
                                                 localRepositoryUrl)
                     .setSnapshotPolicy(new RepositoryPolicy(true,

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/LocalArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/LocalArtifactRepository.java
@@ -30,7 +30,10 @@ import org.guvnor.common.services.project.model.GAV;
 
 public class LocalArtifactRepository implements ArtifactRepository {
 
-    private final String name;
+    private String name;
+
+    public LocalArtifactRepository() {
+    }
 
     public LocalArtifactRepository(final String name) {
         this.name = name;
@@ -39,6 +42,11 @@ public class LocalArtifactRepository implements ArtifactRepository {
     @Override
     public String getName() {
         return name;
+    }
+
+    @Override
+    public String getRootDir() {
+        return this.getRootDir();
     }
 
     @Override
@@ -59,6 +67,16 @@ public class LocalArtifactRepository implements ArtifactRepository {
     @Override
     public File getArtifactFileFromRepository(final GAV gav) {
         return null;
+    }
+
+    @Override
+    public boolean isRepository() {
+        return true;
+    }
+
+    @Override
+    public boolean isPomRepository() {
+        return true;
     }
 
     @Override

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
@@ -38,6 +38,7 @@ import org.eclipse.aether.installation.InstallationException;
 import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.guvnor.common.services.project.model.GAV;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryFactory;
 import org.guvnor.m2repo.preferences.ArtifactRepositoryPreference;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -56,178 +57,183 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.cdi.workspace.WorkspaceNameResolver;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(Aether.class)
-@PowerMockIgnore({ "javax.crypto.*" })
+@PowerMockIgnore({"javax.crypto.*"})
 public class GuvnorM2RepositoryTest {
 
     public static final String KIE_SETTINGS_CUSTOM_KEY = "kie.maven.settings.custom";
     public static final String SETTINGS_SECURITY_KEY = "settings.security";
 
-    private static final Logger log = LoggerFactory.getLogger( GuvnorM2RepositoryTest.class );
+    private static final Logger log = LoggerFactory.getLogger(GuvnorM2RepositoryTest.class);
     private static String settingsSecurityOriginalValue;
     private static String kieSettingsCustomOriginalValue;
 
     private GuvnorM2Repository repo;
-    private RepositorySystem repositorySystem = mock( RepositorySystem.class );
-    private RepositorySystemSession repositorySystemSession = mock( RepositorySystemSession.class );
+    private RepositorySystem repositorySystem = mock(RepositorySystem.class);
+    private RepositorySystemSession repositorySystemSession = mock(RepositorySystemSession.class);
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
     @BeforeClass
     public static void setupClass() throws IOException, URISyntaxException {
-        settingsSecurityOriginalValue = System.getProperty( SETTINGS_SECURITY_KEY );
-        System.setProperty( SETTINGS_SECURITY_KEY,
-                            resolveFilePath( "settings-security.xml" ) );
-        kieSettingsCustomOriginalValue = System.getProperty( KIE_SETTINGS_CUSTOM_KEY );
-        System.setProperty( KIE_SETTINGS_CUSTOM_KEY,
-                            resolveFilePath( "settings.xml" ) );
+        settingsSecurityOriginalValue = System.getProperty(SETTINGS_SECURITY_KEY);
+        System.setProperty(SETTINGS_SECURITY_KEY,
+                           resolveFilePath("settings-security.xml"));
+        kieSettingsCustomOriginalValue = System.getProperty(KIE_SETTINGS_CUSTOM_KEY);
+        System.setProperty(KIE_SETTINGS_CUSTOM_KEY,
+                           resolveFilePath("settings.xml"));
     }
 
-    private static String resolveFilePath( String value ) throws URISyntaxException {
-        final URL url = GuvnorM2RepositoryTest.class.getResource( value );
+    private static String resolveFilePath(String value) throws URISyntaxException {
+        final URL url = GuvnorM2RepositoryTest.class.getResource(value);
         final URI uri = url.toURI();
-        final File f = new File( uri );
+        final File f = new File(uri);
         return f.getAbsolutePath();
     }
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        nullSafeSetProperty( SETTINGS_SECURITY_KEY,
-                             settingsSecurityOriginalValue );
-        nullSafeSetProperty( KIE_SETTINGS_CUSTOM_KEY,
-                             kieSettingsCustomOriginalValue );
+        nullSafeSetProperty(SETTINGS_SECURITY_KEY,
+                            settingsSecurityOriginalValue);
+        nullSafeSetProperty(KIE_SETTINGS_CUSTOM_KEY,
+                            kieSettingsCustomOriginalValue);
     }
 
-    private static void nullSafeSetProperty( final String propertyKey,
-                                             final String propertyValue ) {
-        System.setProperty( propertyKey,
-                            propertyValue == null ? "" : propertyValue );
+    private static void nullSafeSetProperty(final String propertyKey,
+                                            final String propertyValue) {
+        System.setProperty(propertyKey,
+                           propertyValue == null ? "" : propertyValue);
     }
 
     @Before
     public void setup() throws Exception {
-        log.info( "Deleting existing Repositories instance.." );
+        log.info("Deleting existing Repositories instance..");
         ArtifactRepositoryPreference pref = mock(ArtifactRepositoryPreference.class);
-        when(pref.getDefaultM2RepoDir()).thenReturn( "repositories/kie" );
-        repo = new GuvnorM2Repository(pref);
+        when(pref.getGlobalM2RepoDir()).thenReturn("repositories/kie");
+        when(pref.isGlobalM2RepoDirEnabled()).thenReturn(true);
+        when(pref.isDistributionManagementM2RepoDirEnabled()).thenReturn(true);
+        when(pref.isWorkspaceM2RepoDirEnabled()).thenReturn(false);
+        WorkspaceNameResolver resolver = mock(WorkspaceNameResolver.class);
+        when(resolver.getWorkspaceName()).thenReturn("global");
+        ArtifactRepositoryFactory factory = new ArtifactRepositoryFactory(pref,
+                                                                          resolver);
+        factory.initialize();
+        repo = new GuvnorM2Repository(factory);
         repo.init();
 
-        Aether aether = mock( Aether.class );
-        when( aether.getSession() ).thenReturn( repositorySystemSession );
-        when( aether.getSystem() ).thenReturn( repositorySystem );
+        Aether aether = mock(Aether.class);
+        when(aether.getSession()).thenReturn(repositorySystemSession);
+        when(aether.getSystem()).thenReturn(repositorySystem);
 
-        mockStatic( Aether.class );
-        when( Aether.getAether() ).thenReturn( aether );
+        mockStatic(Aether.class);
+        when(Aether.getAether()).thenReturn(aether);
 
         try {
-            when( repositorySystem.install( any( RepositorySystemSession.class ), any( InstallRequest.class ) ) )
-                    .thenAnswer( new Answer<InstallResult>() {
+            when(repositorySystem.install(any(RepositorySystemSession.class),
+                                          any(InstallRequest.class)))
+                    .thenAnswer(new Answer<InstallResult>() {
                         @Override
-                        public InstallResult answer( InvocationOnMock invocation ) throws Throwable {
-                            return new InstallResult( (InstallRequest) invocation.getArguments()[ 1 ] );
+                        public InstallResult answer(InvocationOnMock invocation) throws Throwable {
+                            return new InstallResult((InstallRequest) invocation.getArguments()[1]);
                         }
-                    } );
-        } catch ( InstallationException e ) {
+                    });
+        } catch (InstallationException e) {
             e.printStackTrace();
         }
     }
 
     @Test
     public void testDeployArtifactWithDeployArtifactDistributionManagement() throws Exception {
-        final GAV gav = new GAV( "org.kie.guvnor",
-                                 "guvnor-m2repo-editor-backend",
-                                 "0.0.1-SNAPSHOT" );
+        final GAV gav = new GAV("org.kie.guvnor",
+                                "guvnor-m2repo-editor-backend",
+                                "0.0.1-SNAPSHOT");
 
-        final InputStream is = this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-with-distribution-management.jar" );
-        repo.deployArtifact( is,
-                             gav,
-                             true );
+        final InputStream is = this.getClass().getResourceAsStream("guvnor-m2repo-editor-backend-test-with-distribution-management.jar");
+        repo.deployArtifact(is,
+                            gav,
+                            true);
 
-        verify( repositorySystem,
-                times( 1 ) ).deploy( any( RepositorySystemSession.class ),
-                                     argThat( new BaseMatcher<DeployRequest>() {
+        verify(repositorySystem,
+               times(1)).deploy(any(RepositorySystemSession.class),
+                                argThat(new BaseMatcher<DeployRequest>() {
 
-                                         @Override
-                                         public void describeTo( Description description ) {
-                                         }
+                                    @Override
+                                    public void describeTo(Description description) {
+                                    }
 
-                                         @Override
-                                         public boolean matches( Object item ) {
-                                             DeployRequest request = (DeployRequest) item;
-                                             return "guvnor-m2-repo".equals( request.getRepository().getId() );
-                                         }
+                                    @Override
+                                    public boolean matches(Object item) {
+                                        DeployRequest request = (DeployRequest) item;
+                                        return "global-m2-repo".equals(request.getRepository().getId());
+                                    }
+                                }));
+        verify(repositorySystem,
+               times(1)).deploy(any(RepositorySystemSession.class),
+                                argThat(new BaseMatcher<DeployRequest>() {
 
-                                     } ) );
-        verify( repositorySystem,
-                times( 1 ) ).deploy( any( RepositorySystemSession.class ),
-                                     argThat( new BaseMatcher<DeployRequest>() {
+                                    @Override
+                                    public void describeTo(Description description) {
+                                    }
 
-                                         @Override
-                                         public void describeTo( Description description ) {
-                                         }
-
-                                         @Override
-                                         public boolean matches( Object item ) {
-                                             DeployRequest request = (DeployRequest) item;
-                                             String string = "example.project.http";
-                                             RemoteRepository repo = request.getRepository();
-                                             boolean equals = string.equals( repo.getId() );
-                                             if ( !equals ) {
-                                                 return false;
-                                             }
-                                             Authentication auth = repo.getAuthentication();
-                                             Class<? extends Authentication> class1 = auth.getClass();
-                                             try {
-                                                 Field declaredField = class1.getDeclaredField( "authentications" );
-                                                 declaredField.setAccessible( true );
-                                                 Authentication[] object = (Authentication[]) declaredField.get( auth );
-                                                 Authentication authentication = object[ 1 ];
-                                                 Class<? extends Authentication> class2 = authentication.getClass();
-                                                 boolean equals3 = "SecretAuthentication".equals( class2.getSimpleName() );
-                                                 if ( equals3 ) {
-                                                     Field valueField = class2.getDeclaredField( "value" );
-                                                     valueField.setAccessible( true );
-                                                     // length of plaintext password, obviously not
-                                                     // length of encrypted password
-                                                     assertEquals( "Plaintext pw (repopw) length expected.", 6, ( (char[]) valueField.get( authentication ) ).length );
-                                                 }
-                                                 return "StringAuthentication".equals( object[ 0 ].getClass().getSimpleName() ) && equals3;
-                                             } catch ( Exception e ) {
-                                                 e.printStackTrace();
-                                                 throw new RuntimeException( e );
-                                             }
-                                         }
-
-                                     } ) );
+                                    @Override
+                                    public boolean matches(Object item) {
+                                        DeployRequest request = (DeployRequest) item;
+                                        String string = "example.project.http";
+                                        RemoteRepository repo = request.getRepository();
+                                        boolean equals = string.equals(repo.getId());
+                                        if (!equals) {
+                                            return false;
+                                        }
+                                        Authentication auth = repo.getAuthentication();
+                                        Class<? extends Authentication> class1 = auth.getClass();
+                                        try {
+                                            Field declaredField = class1.getDeclaredField("authentications");
+                                            declaredField.setAccessible(true);
+                                            Authentication[] object = (Authentication[]) declaredField.get(auth);
+                                            Authentication authentication = object[1];
+                                            Class<? extends Authentication> class2 = authentication.getClass();
+                                            boolean equals3 = "SecretAuthentication".equals(class2.getSimpleName());
+                                            if (equals3) {
+                                                Field valueField = class2.getDeclaredField("value");
+                                                valueField.setAccessible(true);
+                                                // length of plaintext password, obviously not
+                                                // length of encrypted password
+                                                assertEquals("Plaintext pw (repopw) length expected.",
+                                                             6,
+                                                             ((char[]) valueField.get(authentication)).length);
+                                            }
+                                            return "StringAuthentication".equals(object[0].getClass().getSimpleName()) && equals3;
+                                        } catch (Exception e) {
+                                            e.printStackTrace();
+                                            throw new RuntimeException(e);
+                                        }
+                                    }
+                                }));
     }
 
     @Test
     public void testListFilesWithoutParameters() {
         List<String> wildcards = new ArrayList<String>();
-        wildcards.add( "*.jar" );
-        wildcards.add( "*.kjar" );
-        wildcards.add( "*.pom" );
+        wildcards.add("*.jar");
+        wildcards.add("*.kjar");
+        wildcards.add("*.pom");
 
-        GuvnorM2Repository spiedRepo = spy( repo );
+        GuvnorM2Repository spiedRepo = spy(repo);
 
-        doReturn( new ArrayList<String>() ).when( spiedRepo ).getFiles( Matchers.<List<String>>any() );
+        doReturn(new ArrayList<String>()).when(spiedRepo).getFiles(Matchers.<List<String>>any());
 
         spiedRepo.listFiles();
-        verify( spiedRepo ).getFiles( wildcards );
+        verify(spiedRepo).getFiles(wildcards);
     }
 
     @Test
@@ -235,16 +241,16 @@ public class GuvnorM2RepositoryTest {
         final String filter = "filter";
 
         List<String> wildcards = new ArrayList<String>();
-        wildcards.add( "*" + filter + "*.jar" );
-        wildcards.add( "*" + filter + "*.kjar" );
-        wildcards.add( "*" + filter + "*.pom" );
+        wildcards.add("*" + filter + "*.jar");
+        wildcards.add("*" + filter + "*.kjar");
+        wildcards.add("*" + filter + "*.pom");
 
-        GuvnorM2Repository spiedRepo = spy( repo );
+        GuvnorM2Repository spiedRepo = spy(repo);
 
-        doReturn( new ArrayList<String>() ).when( spiedRepo ).getFiles( Matchers.<List<String>>any() );
+        doReturn(new ArrayList<String>()).when(spiedRepo).getFiles(Matchers.<List<String>>any());
 
-        spiedRepo.listFiles( filter );
-        verify( spiedRepo ).getFiles( wildcards );
+        spiedRepo.listFiles(filter);
+        verify(spiedRepo).getFiles(wildcards);
     }
 
     @Test
@@ -252,29 +258,29 @@ public class GuvnorM2RepositoryTest {
         final String filter = "filter";
 
         List<String> fileFormats = new ArrayList<String>();
-        fileFormats.add( "xml" );
-        fileFormats.add( "war" );
+        fileFormats.add("xml");
+        fileFormats.add("war");
 
         List<String> wildcards = new ArrayList<String>();
-        wildcards.add( "*" + filter + "*.xml" );
-        wildcards.add( "*" + filter + "*.war" );
+        wildcards.add("*" + filter + "*.xml");
+        wildcards.add("*" + filter + "*.war");
 
-        GuvnorM2Repository spiedRepo = spy( repo );
+        GuvnorM2Repository spiedRepo = spy(repo);
 
-        doReturn( new ArrayList<String>() ).when( spiedRepo ).getFiles( Matchers.<List<String>>any() );
+        doReturn(new ArrayList<String>()).when(spiedRepo).getFiles(Matchers.<List<String>>any());
 
-        spiedRepo.listFiles( filter, fileFormats );
-        verify( spiedRepo ).getFiles( wildcards );
+        spiedRepo.listFiles(filter,
+                            fileFormats);
+        verify(spiedRepo).getFiles(wildcards);
     }
 
     @Test
     public void testGetPomTextVerifiesPath() {
-        GuvnorM2Repository.getPomText( "dir/name.pom" );
-        GuvnorM2Repository.getPomText( "dir/name.kjar" );
-        GuvnorM2Repository.getPomText( "dir/name.jar" );
+        repo.getPomText("dir/name.pom");
+        repo.getPomText("dir/name.kjar");
+        repo.getPomText("dir/name.jar");
 
-        exception.expect( RuntimeException.class );
-        GuvnorM2Repository.getPomText( "dir/name.foo" );
+        exception.expect(RuntimeException.class);
+        repo.getPomText("dir/name.foo");
     }
-
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/M2RepositoryServiceImplTest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/M2RepositoryServiceImplTest.java
@@ -29,14 +29,13 @@ import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
-import javax.enterprise.inject.Instance;
-
 import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemHeaders;
 import org.eclipse.aether.artifact.Artifact;
 import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.m2repo.backend.server.helpers.FormData;
 import org.guvnor.m2repo.backend.server.helpers.HttpPostHelper;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryFactory;
 import org.guvnor.m2repo.model.JarListPageRequest;
 import org.guvnor.m2repo.model.JarListPageRow;
 import org.guvnor.m2repo.preferences.ArtifactRepositoryPreference;
@@ -51,6 +50,7 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.uberfire.backend.server.cdi.workspace.WorkspaceNameResolver;
 import org.uberfire.paging.PageResponse;
 
 import static org.guvnor.m2repo.model.HTMLFileManagerFields.UPLOAD_OK;
@@ -63,7 +63,7 @@ import static org.mockito.Mockito.*;
 
 public class M2RepositoryServiceImplTest {
 
-    private static final Logger log = LoggerFactory.getLogger( M2RepositoryServiceImplTest.class );
+    private static final Logger log = LoggerFactory.getLogger(M2RepositoryServiceImplTest.class);
     private static GAV gavBackend;
     private static GAV gavBackend1;
     private static GAV gavBackend2;
@@ -79,70 +79,81 @@ public class M2RepositoryServiceImplTest {
 
     @BeforeClass
     public static void setupClass() {
-        gavBackend = new GAV( "org.kie.guvnor",
-                              "guvnor-m2repo-editor-backend",
-                              "0.0.1-SNAPSHOT" );
+        gavBackend = new GAV("org.kie.guvnor",
+                             "guvnor-m2repo-editor-backend",
+                             "0.0.1-SNAPSHOT");
 
-        gavBackend1 = new GAV( "org.kie.guvnor",
-                               "guvnor-m2repo-editor-backend1",
-                               "0.0.1-SNAPSHOT" );
+        gavBackend1 = new GAV("org.kie.guvnor",
+                              "guvnor-m2repo-editor-backend1",
+                              "0.0.1-SNAPSHOT");
 
-        gavBackend2 = new GAV( "org.kie.guvnor",
-                               "guvnor-m2repo-editor-backend2",
-                               "0.0.1-SNAPSHOT" );
+        gavBackend2 = new GAV("org.kie.guvnor",
+                              "guvnor-m2repo-editor-backend2",
+                              "0.0.1-SNAPSHOT");
 
-        gavArquillian = new GAV( "org.jboss.arquillian.core",
-                                 "arquillian-core-api",
-                                 "1.0.2.Final" );
+        gavArquillian = new GAV("org.jboss.arquillian.core",
+                                "arquillian-core-api",
+                                "1.0.2.Final");
     }
 
     @Before
     public void setup() throws Exception {
-        log.info( "Deleting existing Repositories instance.." );
+        log.info("Deleting existing Repositories instance..");
 
-        File dir = new File( "repositories" );
-        log.info( "DELETING test repo: " + dir.getAbsolutePath() );
-        deleteDir( dir );
-        log.info( "TEST repo was deleted." );
+        File dir = new File("repositories");
+        log.info("DELETING test repo: " + dir.getAbsolutePath());
+        deleteDir(dir);
+        log.info("TEST repo was deleted.");
 
-        ArtifactRepositoryPreference pref = mock( ArtifactRepositoryPreference.class );
-        when(pref.getDefaultM2RepoDir()).thenReturn( "repositories/kie" );
-        repo = new GuvnorM2Repository( pref );
+        ArtifactRepositoryPreference pref = mock(ArtifactRepositoryPreference.class);
+        when(pref.getGlobalM2RepoDir()).thenReturn("repositories/kie");
+        when(pref.isGlobalM2RepoDirEnabled()).thenReturn(true);
+        when(pref.isDistributionManagementM2RepoDirEnabled()).thenReturn(true);
+        when(pref.isWorkspaceM2RepoDirEnabled()).thenReturn(false);
+        WorkspaceNameResolver resolver = mock(WorkspaceNameResolver.class);
+        when(resolver.getWorkspaceName()).thenReturn("global");
+        ArtifactRepositoryFactory factory = new ArtifactRepositoryFactory(pref,
+                                                                          resolver);
+        factory.initialize();
+        repo = new GuvnorM2Repository(factory);
         repo.init();
 
         //Create a shell M2RepoService and set the M2Repository
-        service = new M2RepoServiceImpl();
-        java.lang.reflect.Field repositoryField = M2RepoServiceImpl.class.getDeclaredField( "repository" );
-        repositoryField.setAccessible( true );
-        repositoryField.set( service, repo );
+        service = new M2RepoServiceImpl(this.repo);
+        java.lang.reflect.Field repositoryField = M2RepoServiceImpl.class.getDeclaredField("repository");
+        repositoryField.setAccessible(true);
+        repositoryField.set(service,
+                            repo);
 
         //Make private method accessible for testing
         helper = new HttpPostHelper();
-        helperMethod = HttpPostHelper.class.getDeclaredMethod( "upload", FormData.class );
-        helperMethod.setAccessible( true );
+        helperMethod = HttpPostHelper.class.getDeclaredMethod("upload",
+                                                              FormData.class);
+        helperMethod.setAccessible(true);
 
         //Set the repository service created above in the HttpPostHelper
-        java.lang.reflect.Field m2RepoServiceField = HttpPostHelper.class.getDeclaredField( "m2RepoService" );
-        m2RepoServiceField.setAccessible( true );
-        m2RepoServiceField.set( helper, service );
+        java.lang.reflect.Field m2RepoServiceField = HttpPostHelper.class.getDeclaredField("m2RepoService");
+        m2RepoServiceField.setAccessible(true);
+        m2RepoServiceField.set(helper,
+                               service);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        log.info( "Deleting all Repository instances.." );
+        log.info("Deleting all Repository instances..");
 
-        File dir = new File( "repositories" );
-        log.info( "DELETING test repo: " + dir.getAbsolutePath() );
-        deleteDir( dir );
-        log.info( "TEST repo was deleted." );
+        File dir = new File("repositories");
+        log.info("DELETING test repo: " + dir.getAbsolutePath());
+        deleteDir(dir);
+        log.info("TEST repo was deleted.");
     }
 
-    public static boolean deleteDir( File dir ) {
-        if ( dir.isDirectory() ) {
+    public static boolean deleteDir(File dir) {
+        if (dir.isDirectory()) {
             String[] children = dir.list();
-            for ( int i = 0; i < children.length; i++ ) {
-                if ( !deleteDir( new File( dir,
-                                           children[ i ] ) ) ) {
+            for (int i = 0; i < children.length; i++) {
+                if (!deleteDir(new File(dir,
+                                        children[i]))) {
                     return false;
                 }
             }
@@ -154,133 +165,137 @@ public class M2RepositoryServiceImplTest {
 
     @Test
     public void testDeployArtifact() throws Exception {
-        deployArtifact( gavBackend );
+        deployArtifact(gavBackend);
 
         Collection<File> files = repo.listFiles();
 
         boolean found = false;
-        for ( File file : files ) {
+        for (File file : files) {
             String fileName = file.getName();
-            if ( fileName.startsWith( "guvnor-m2repo-editor-backend-0.0.1" ) && fileName.endsWith( ".jar" ) ) {
+            if (fileName.startsWith("guvnor-m2repo-editor-backend-0.0.1") && fileName.endsWith(".jar")) {
                 found = true;
                 String path = file.getPath();
-                String jarPath = path.substring( GuvnorM2Repository.M2_REPO_DIR.length() + 1 );
-                String pom = GuvnorM2Repository.getPomText( jarPath );
-                assertNotNull( pom );
+                String jarPath = path.substring(repo.getM2RepositoryRootDir(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME).length());
+                String pom = repo.getPomText(jarPath);
+                assertNotNull(pom);
                 break;
             }
         }
 
-        assertTrue( "Did not find expected file after calling M2Repository.addFile()",
-                    found );
+        assertTrue("Did not find expected file after calling M2Repository.addFile()",
+                   found);
 
         // Test get artifact file
-        File file = repo.getArtifactFileFromRepository( gavBackend );
-        assertNotNull( "Empty file for artifact", file );
-        JarFile jarFile = new JarFile( file );
+        File file = repo.getArtifactFileFromRepository(gavBackend);
+        assertNotNull("Empty file for artifact",
+                      file);
+        JarFile jarFile = new JarFile(file);
         int count = 0;
 
         String lastEntryName = null;
-        for ( Enumeration<JarEntry> entries = jarFile.entries(); entries.hasMoreElements(); ) {
+        for (Enumeration<JarEntry> entries = jarFile.entries(); entries.hasMoreElements(); ) {
             ++count;
             JarEntry entry = entries.nextElement();
-            assertNotEquals( "Endless loop.", lastEntryName, entry.getName() );
+            assertNotEquals("Endless loop.",
+                            lastEntryName,
+                            entry.getName());
         }
-        assertTrue( "Empty jar file!", count > 0 );
+        assertTrue("Empty jar file!",
+                   count > 0);
     }
 
     @Test
     public void testDeployPom() throws Exception {
-        InputStream is = this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-pom.xml" );
-        repo.deployPom( is,
-                        gavBackend );
+        InputStream is = this.getClass().getResourceAsStream("guvnor-m2repo-editor-backend-test-pom.xml");
+        repo.deployPom(is,
+                       gavBackend);
 
         Collection<File> files = repo.listFiles();
 
         boolean found = false;
-        for ( File file : files ) {
+        for (File file : files) {
             String fileName = file.getName();
-            if ( fileName.startsWith( "guvnor-m2repo-editor-backend-0.0.1" ) && fileName.endsWith( ".pom" ) ) {
+            if (fileName.startsWith("guvnor-m2repo-editor-backend-0.0.1") && fileName.endsWith(".pom")) {
                 found = true;
                 String path = file.getPath();
-                String jarPath = path.substring( GuvnorM2Repository.M2_REPO_DIR.length() + 1 );
-                String pom = GuvnorM2Repository.getPomText( jarPath );
-                assertNotNull( pom );
+                String jarPath = path.substring(repo.getM2RepositoryRootDir(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME).length());
+                String pom = repo.getPomText(jarPath);
+                assertNotNull(pom);
                 break;
             }
         }
 
-        assertTrue( "Did not find expected file after calling M2Repository.addFile()",
-                    found );
+        assertTrue("Did not find expected file after calling M2Repository.addFile()",
+                   found);
     }
 
     @Test
     public void testListFiles() throws Exception {
-        deployArtifact( gavBackend );
-        deployArtifact( gavArquillian );
+        deployArtifact(gavBackend);
+        deployArtifact(gavArquillian);
 
         Collection<File> files = repo.listFiles();
 
         boolean found1 = false;
         boolean found2 = false;
-        for ( File file : files ) {
+        for (File file : files) {
             String fileName = file.getName();
-            if ( fileName.startsWith( "guvnor-m2repo-editor-backend-0.0.1" ) && fileName.endsWith( ".jar" ) ) {
+            if (fileName.startsWith("guvnor-m2repo-editor-backend-0.0.1") && fileName.endsWith(".jar")) {
                 found1 = true;
             }
-            if ( fileName.startsWith( "arquillian-core-api-1.0.2.Final" ) && fileName.endsWith( ".jar" ) ) {
+            if (fileName.startsWith("arquillian-core-api-1.0.2.Final") && fileName.endsWith(".jar")) {
                 found2 = true;
             }
         }
 
-        assertTrue( "Did not find expected file after calling M2Repository.addFile()",
-                    found1 );
-        assertTrue( "Did not find expected file after calling M2Repository.addFile()",
-                    found2 );
+        assertTrue("Did not find expected file after calling M2Repository.addFile()",
+                   found1);
+        assertTrue("Did not find expected file after calling M2Repository.addFile()",
+                   found2);
     }
 
     @Test
     public void testListFilesWithFilter() throws Exception {
-        deployArtifact( gavBackend );
-        deployArtifact( gavArquillian );
+        deployArtifact(gavBackend);
+        deployArtifact(gavArquillian);
 
         //filter with version number
         boolean found1 = false;
-        Collection<File> files = repo.listFiles( "1.0.2" );
+        Collection<File> files = repo.listFiles("1.0.2");
         final String VERSION_NUMBER_SEARCH_FILTER = "arquillian-core-api-1.0.2";
-        for ( File file : files ) {
+        for (File file : files) {
             String fileName = file.getName();
-            if ( fileName.startsWith( VERSION_NUMBER_SEARCH_FILTER ) && fileName.endsWith( ".jar" ) ) {
+            if (fileName.startsWith(VERSION_NUMBER_SEARCH_FILTER) && fileName.endsWith(".jar")) {
                 found1 = true;
             }
         }
-        assertTrue( "Did not find expected file after calling M2Repository.addFile()",
-                    found1 );
+        assertTrue("Did not find expected file after calling M2Repository.addFile()",
+                   found1);
 
-        for ( File file : files ) {
+        for (File file : files) {
             String fileName = file.getName();
-            if ( !fileName.contains( VERSION_NUMBER_SEARCH_FILTER ) ) {
-                Assert.fail( fileName + " doesn't match the filter " + VERSION_NUMBER_SEARCH_FILTER );
+            if (!fileName.contains(VERSION_NUMBER_SEARCH_FILTER)) {
+                Assert.fail(fileName + " doesn't match the filter " + VERSION_NUMBER_SEARCH_FILTER);
             }
         }
 
         //filter with artifact id
         found1 = false;
-        files = repo.listFiles( "arquillian-core-api" );
+        files = repo.listFiles("arquillian-core-api");
         final String ARTIFACT_SEARCH_FILTER = "arquillian-core-api";
-        for ( File file : files ) {
+        for (File file : files) {
             String fileName = file.getName();
-            if ( fileName.startsWith( ARTIFACT_SEARCH_FILTER ) && fileName.endsWith( ".jar" ) ) {
+            if (fileName.startsWith(ARTIFACT_SEARCH_FILTER) && fileName.endsWith(".jar")) {
                 found1 = true;
             }
         }
-        assertTrue( "Did not find expected file after calling M2Repository.addFile()",
-                    found1 );
+        assertTrue("Did not find expected file after calling M2Repository.addFile()",
+                   found1);
 
-        for ( File file : files ) {
+        for (File file : files) {
             String fileName = file.getName();
-            if ( !fileName.contains( ARTIFACT_SEARCH_FILTER ) ) {
-                Assert.fail( fileName + " doesn't match the filter " + ARTIFACT_SEARCH_FILTER );
+            if (!fileName.contains(ARTIFACT_SEARCH_FILTER)) {
+                Assert.fail(fileName + " doesn't match the filter " + ARTIFACT_SEARCH_FILTER);
             }
         }
     }
@@ -288,47 +303,47 @@ public class M2RepositoryServiceImplTest {
     @Test
     public void testUploadJARWithPOM() throws Exception {
         FormData uploadItem = new FormData();
-        FileItem file = new MockFileItem( "guvnor-m2repo-editor-backend-test-with-pom.jar",
-                                          this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-with-pom.jar" ) );
-        uploadItem.setFile( file );
+        FileItem file = new MockFileItem("guvnor-m2repo-editor-backend-test-with-pom.jar",
+                                         this.getClass().getResourceAsStream("guvnor-m2repo-editor-backend-test-with-pom.jar"));
+        uploadItem.setFile(file);
 
-        assert ( helperMethod.invoke( helper,
-                                      uploadItem ).equals( UPLOAD_OK ) );
+        assert (helperMethod.invoke(helper,
+                                    uploadItem).equals(UPLOAD_OK));
     }
 
     @Test
     public void testUploadKJARWithPOM() throws Exception {
         FormData uploadItem = new FormData();
-        FileItem file = new MockFileItem( "guvnor-m2repo-editor-backend-test-with-pom.kjar",
-                                          this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-with-pom.jar" ) );
-        uploadItem.setFile( file );
+        FileItem file = new MockFileItem("guvnor-m2repo-editor-backend-test-with-pom.kjar",
+                                         this.getClass().getResourceAsStream("guvnor-m2repo-editor-backend-test-with-pom.jar"));
+        uploadItem.setFile(file);
 
-        assert ( helperMethod.invoke( helper,
-                                      uploadItem ).equals( UPLOAD_OK ) );
+        assert (helperMethod.invoke(helper,
+                                    uploadItem).equals(UPLOAD_OK));
     }
 
     @Test
     public void testUploadJARWithManualGAV() throws Exception {
         FormData uploadItem = new FormData();
-        uploadItem.setGav( gavBackend );
-        FileItem file = new MockFileItem( "guvnor-m2repo-editor-backend-test-without-pom.jar",
-                                          this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-without-pom.jar" ) );
-        uploadItem.setFile( file );
+        uploadItem.setGav(gavBackend);
+        FileItem file = new MockFileItem("guvnor-m2repo-editor-backend-test-without-pom.jar",
+                                         this.getClass().getResourceAsStream("guvnor-m2repo-editor-backend-test-without-pom.jar"));
+        uploadItem.setFile(file);
 
-        assert ( helperMethod.invoke( helper,
-                                      uploadItem ).equals( UPLOAD_OK ) );
+        assert (helperMethod.invoke(helper,
+                                    uploadItem).equals(UPLOAD_OK));
     }
 
     @Test
     public void testUploadKJARWithManualGAV() throws Exception {
         FormData uploadItem = new FormData();
-        uploadItem.setGav( gavBackend );
-        FileItem file = new MockFileItem( "guvnor-m2repo-editor-backend-test.kjar",
-                                          this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-without-pom.jar" ) );
-        uploadItem.setFile( file );
+        uploadItem.setGav(gavBackend);
+        FileItem file = new MockFileItem("guvnor-m2repo-editor-backend-test.kjar",
+                                         this.getClass().getResourceAsStream("guvnor-m2repo-editor-backend-test-without-pom.jar"));
+        uploadItem.setFile(file);
 
-        assert ( helperMethod.invoke( helper,
-                                      uploadItem ).equals( UPLOAD_OK ) );
+        assert (helperMethod.invoke(helper,
+                                    uploadItem).equals(UPLOAD_OK));
     }
 
     /**
@@ -343,34 +358,43 @@ public class M2RepositoryServiceImplTest {
         final int TOTAL = 5;
         final int PAGE_START = 1;
         final int PAGE_SIZE = 2;
-        for ( int i = 0; i < TOTAL; i++ ) {
-            final ArtifactImpl artifact = new ArtifactImpl( new File( repo.M2_REPO_DIR, "path/x" + i ) );
+        for (int i = 0; i < TOTAL; i++) {
+            final ArtifactImpl artifact = new ArtifactImpl(new File(repo.getM2RepositoryRootDir(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME),
+                                                                    "path/x" + i));
             final HashMap<String, String> map = new HashMap<String, String>();
-            map.put( "repository","guvnor-m2-repo" );
-            artifact.setProperties( map );
-            artifacts.add( artifact );
+            map.put("repository",
+                    "guvnor-m2-repo");
+            artifact.setProperties(map);
+            artifacts.add(artifact);
         }
         // Create a mock repository to make the test independent on any project deployment
-        GuvnorM2Repository mockRepo = mock( GuvnorM2Repository.class );
-        Mockito.when( mockRepo.listArtifacts( Mockito.anyString(), Matchers.<List<String>>any() ) )
-                .thenReturn( artifacts );
+        GuvnorM2Repository mockRepo = mock(GuvnorM2Repository.class);
+        Mockito.when(mockRepo.listArtifacts(Mockito.anyString(),
+                                            Matchers.<List<String>>any()))
+                .thenReturn(artifacts);
+        when(mockRepo.getM2RepositoryDir(any())).thenReturn(repo.getM2RepositoryDir(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME));
 
         // Create a shell M2RepoService with injected mock M2Repository
-        M2RepoServiceImpl m2service = new M2RepoServiceImpl();
-        java.lang.reflect.Field repositoryField = M2RepoServiceImpl.class.getDeclaredField( "repository" );
-        repositoryField.setAccessible( true );
-        repositoryField.set( m2service,
-                             mockRepo );
+        M2RepoServiceImpl m2service = new M2RepoServiceImpl(mockRepo);
 
         // Verify PageResponse
-        JarListPageRequest request = new JarListPageRequest( PAGE_START, PAGE_SIZE, null, null, null, false );
-        PageResponse<JarListPageRow> response = m2service.listArtifacts( request );
-        assertEquals( PAGE_SIZE, response.getPageRowList().size() );
-        assertEquals( TOTAL, response.getTotalRowSize() );
+        JarListPageRequest request = new JarListPageRequest(PAGE_START,
+                                                            PAGE_SIZE,
+                                                            null,
+                                                            null,
+                                                            null,
+                                                            false);
+        PageResponse<JarListPageRow> response = m2service.listArtifacts(request);
+        assertEquals(PAGE_SIZE,
+                     response.getPageRowList().size());
+        assertEquals(TOTAL,
+                     response.getTotalRowSize());
         int i = PAGE_START;
-        for ( JarListPageRow row : response.getPageRowList() ) {
-            assertEquals( "x" + i, row.getName() );
-            assertEquals( "path/x" + i, row.getPath() );
+        for (JarListPageRow row : response.getPageRowList()) {
+            assertEquals("x" + i,
+                         row.getName());
+            assertEquals("path/x" + i,
+                         row.getPath());
             i += 1;
         }
     }
@@ -378,279 +402,287 @@ public class M2RepositoryServiceImplTest {
     @Test
     public void testUploadPOM() throws Exception {
         FormData uploadItem = new FormData();
-        FileItem file = new MockFileItem( "pom.xml",
-                                          this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-pom.xml" ) );
-        uploadItem.setFile( file );
+        FileItem file = new MockFileItem("pom.xml",
+                                         this.getClass().getResourceAsStream("guvnor-m2repo-editor-backend-test-pom.xml"));
+        uploadItem.setFile(file);
 
-        assert ( helperMethod.invoke( helper,
-                                      uploadItem ).equals( UPLOAD_OK ) );
+        assert (helperMethod.invoke(helper,
+                                    uploadItem).equals(UPLOAD_OK));
 
-        assertFilesCount( null, null, null, false, 1 );
+        assertFilesCount(null,
+                         null,
+                         null,
+                         false,
+                         1);
     }
 
     @Test
     public void testListFilesWithSortOnNameAscending() throws Exception {
-        deployArtifact( gavBackend1 );
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend1);
+        deployArtifact(gavBackend2);
 
         //Sort by Name ascending
-        final PageResponse<JarListPageRow> response = assertFilesCount( null,
-                                                                        null,
-                                                                        JarListPageRequest.COLUMN_NAME,
-                                                                        true,
-                                                                        4 );
+        final PageResponse<JarListPageRow> response = assertFilesCount(null,
+                                                                       null,
+                                                                       JarListPageRequest.COLUMN_NAME,
+                                                                       true,
+                                                                       4);
         final List<JarListPageRow> files = response.getPageRowList();
-        final String fileName0 = files.get( 0 ).getName();
-        final String fileName2 = files.get( 2 ).getName();
-        assertTrue( fileName0.startsWith( "guvnor-m2repo-editor-backend1" ) );
-        assertTrue( fileName2.startsWith( "guvnor-m2repo-editor-backend2" ) );
+        final String fileName0 = files.get(0).getName();
+        final String fileName2 = files.get(2).getName();
+        assertTrue(fileName0.startsWith("guvnor-m2repo-editor-backend1"));
+        assertTrue(fileName2.startsWith("guvnor-m2repo-editor-backend2"));
     }
 
     @Test
     public void testListFilesWithSortOnNameDescending() throws Exception {
-        deployArtifact( gavBackend1 );
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend1);
+        deployArtifact(gavBackend2);
 
         //Sort by Name descending
-        final PageResponse<JarListPageRow> response = assertFilesCount( null,
-                                                                        null,
-                                                                        JarListPageRequest.COLUMN_NAME,
-                                                                        false,
-                                                                        4 );
+        final PageResponse<JarListPageRow> response = assertFilesCount(null,
+                                                                       null,
+                                                                       JarListPageRequest.COLUMN_NAME,
+                                                                       false,
+                                                                       4);
         final List<JarListPageRow> files = response.getPageRowList();
-        final String fileName0 = files.get( 0 ).getName();
-        final String fileName2 = files.get( 2 ).getName();
-        assertTrue( fileName0.startsWith( "guvnor-m2repo-editor-backend2" ) );
-        assertTrue( fileName2.startsWith( "guvnor-m2repo-editor-backend1" ) );
+        final String fileName0 = files.get(0).getName();
+        final String fileName2 = files.get(2).getName();
+        assertTrue(fileName0.startsWith("guvnor-m2repo-editor-backend2"));
+        assertTrue(fileName2.startsWith("guvnor-m2repo-editor-backend1"));
     }
 
     @Test
     public void testListFilesWithSortOnPathAscending() throws Exception {
-        deployArtifact( gavBackend1 );
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend1);
+        deployArtifact(gavBackend2);
 
         //Sort by Path ascending
-        final PageResponse<JarListPageRow> response = assertFilesCount( null,
-                                                                        null,
-                                                                        JarListPageRequest.COLUMN_PATH,
-                                                                        true,
-                                                                        4 );
+        final PageResponse<JarListPageRow> response = assertFilesCount(null,
+                                                                       null,
+                                                                       JarListPageRequest.COLUMN_PATH,
+                                                                       true,
+                                                                       4);
         final List<JarListPageRow> files = response.getPageRowList();
-        final String filePath0 = files.get( 0 ).getPath();
-        final String filePath2 = files.get( 2 ).getPath();
-        assertTrue( filePath0.contains( "guvnor-m2repo-editor-backend1" ) );
-        assertTrue( filePath2.contains( "guvnor-m2repo-editor-backend2" ) );
+        final String filePath0 = files.get(0).getPath();
+        final String filePath2 = files.get(2).getPath();
+        assertTrue(filePath0.contains("guvnor-m2repo-editor-backend1"));
+        assertTrue(filePath2.contains("guvnor-m2repo-editor-backend2"));
     }
 
     @Test
     public void testListFilesWithSortOnPathDescending() throws Exception {
-        deployArtifact( gavBackend1 );
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend1);
+        deployArtifact(gavBackend2);
 
         //Sort by Path descending
-        final PageResponse<JarListPageRow> response = assertFilesCount( null,
-                                                                        null,
-                                                                        JarListPageRequest.COLUMN_PATH,
-                                                                        false,
-                                                                        4 );
+        final PageResponse<JarListPageRow> response = assertFilesCount(null,
+                                                                       null,
+                                                                       JarListPageRequest.COLUMN_PATH,
+                                                                       false,
+                                                                       4);
         final List<JarListPageRow> files = response.getPageRowList();
-        final String filePath0 = files.get( 0 ).getPath();
-        final String filePath2 = files.get( 2 ).getPath();
-        assertTrue( filePath0.contains( "guvnor-m2repo-editor-backend2" ) );
-        assertTrue( filePath2.contains( "guvnor-m2repo-editor-backend1" ) );
+        final String filePath0 = files.get(0).getPath();
+        final String filePath2 = files.get(2).getPath();
+        assertTrue(filePath0.contains("guvnor-m2repo-editor-backend2"));
+        assertTrue(filePath2.contains("guvnor-m2repo-editor-backend1"));
     }
 
     @Test
     public void testListFilesWithSortOnGavAscending() throws Exception {
-        deployArtifact( gavBackend1 );
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend1);
+        deployArtifact(gavBackend2);
 
         //Sort by GAV ascending
-        final PageResponse<JarListPageRow> response = assertFilesCount( null,
-                                                                        null,
-                                                                        JarListPageRequest.COLUMN_GAV,
-                                                                        true,
-                                                                        4 );
+        final PageResponse<JarListPageRow> response = assertFilesCount(null,
+                                                                       null,
+                                                                       JarListPageRequest.COLUMN_GAV,
+                                                                       true,
+                                                                       4);
         final List<JarListPageRow> files = response.getPageRowList();
-        final GAV gav0 = files.get( 0 ).getGav();
-        final GAV gav2 = files.get( 2 ).getGav();
-        assertEquals( "guvnor-m2repo-editor-backend1",
-                      gav0.getArtifactId() );
-        assertEquals( "guvnor-m2repo-editor-backend2",
-                      gav2.getArtifactId() );
+        final GAV gav0 = files.get(0).getGav();
+        final GAV gav2 = files.get(2).getGav();
+        assertEquals("guvnor-m2repo-editor-backend1",
+                     gav0.getArtifactId());
+        assertEquals("guvnor-m2repo-editor-backend2",
+                     gav2.getArtifactId());
     }
 
     @Test
     public void testListFilesWithSortOnGavDescending() throws Exception {
-        deployArtifact( gavBackend1 );
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend1);
+        deployArtifact(gavBackend2);
 
         //Sort by GAV descending
-        final PageResponse<JarListPageRow> response = assertFilesCount( null,
-                                                                        null,
-                                                                        JarListPageRequest.COLUMN_GAV,
-                                                                        false,
-                                                                        4 );
+        final PageResponse<JarListPageRow> response = assertFilesCount(null,
+                                                                       null,
+                                                                       JarListPageRequest.COLUMN_GAV,
+                                                                       false,
+                                                                       4);
         final List<JarListPageRow> files = response.getPageRowList();
-        final GAV gav0 = files.get( 0 ).getGav();
-        final GAV gav2 = files.get( 2 ).getGav();
-        assertEquals( "guvnor-m2repo-editor-backend2",
-                      gav0.getArtifactId() );
-        assertEquals( "guvnor-m2repo-editor-backend1",
-                      gav2.getArtifactId() );
+        final GAV gav0 = files.get(0).getGav();
+        final GAV gav2 = files.get(2).getGav();
+        assertEquals("guvnor-m2repo-editor-backend2",
+                     gav0.getArtifactId());
+        assertEquals("guvnor-m2repo-editor-backend1",
+                     gav2.getArtifactId());
     }
 
     @Test
     public void testListFilesWithSortOnLastModifiedAscending() throws Exception {
-        deployArtifact( gavBackend1 );
+        deployArtifact(gavBackend1);
 
         //Wait a bit before deploying other file (to ensure different Last Modified times)
-        Thread.sleep( 2000 );
+        Thread.sleep(2000);
 
         //This installs a JAR and a POM
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend2);
 
         //Sort by Last Modified ascending
-        final PageResponse<JarListPageRow> response = assertFilesCount( null,
-                                                                        null,
-                                                                        JarListPageRequest.COLUMN_LAST_MODIFIED,
-                                                                        true,
-                                                                        4 );
+        final PageResponse<JarListPageRow> response = assertFilesCount(null,
+                                                                       null,
+                                                                       JarListPageRequest.COLUMN_LAST_MODIFIED,
+                                                                       true,
+                                                                       4);
         final List<JarListPageRow> files = response.getPageRowList();
-        final Long fileTime0 = files.get( 0 ).getLastModified().getTime();
-        final Long fileTime2 = files.get( 2 ).getLastModified().getTime();
-        assertTrue( fileTime0.compareTo( fileTime2 ) < 0 );
+        final Long fileTime0 = files.get(0).getLastModified().getTime();
+        final Long fileTime2 = files.get(2).getLastModified().getTime();
+        assertTrue(fileTime0.compareTo(fileTime2) < 0);
     }
 
     @Test
     public void testListFilesWithSortOnLastModifiedDescending() throws Exception {
-        deployArtifact( gavBackend1 );
+        deployArtifact(gavBackend1);
 
         //Wait a bit before deploying other file (to ensure different Last Modified times)
-        Thread.sleep( 2000 );
+        Thread.sleep(2000);
 
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend2);
 
         //Sort by Last Modified descending
-        final PageResponse<JarListPageRow> response = assertFilesCount( null,
-                                                                        null,
-                                                                        JarListPageRequest.COLUMN_LAST_MODIFIED,
-                                                                        false,
-                                                                        4 );
+        final PageResponse<JarListPageRow> response = assertFilesCount(null,
+                                                                       null,
+                                                                       JarListPageRequest.COLUMN_LAST_MODIFIED,
+                                                                       false,
+                                                                       4);
         final List<JarListPageRow> files = response.getPageRowList();
-        final Long fileTime0 = files.get( 0 ).getLastModified().getTime();
-        final Long fileTime2 = files.get( 2 ).getLastModified().getTime();
-        assertTrue( fileTime0.compareTo( fileTime2 ) > 0 );
+        final Long fileTime0 = files.get(0).getLastModified().getTime();
+        final Long fileTime2 = files.get(2).getLastModified().getTime();
+        assertTrue(fileTime0.compareTo(fileTime2) > 0);
     }
 
     @Test
     public void testListFilesIncludingPom() throws Exception {
-        deployArtifact( gavBackend );
+        deployArtifact(gavBackend);
 
         //This installs a POM
-        GAV gavBackendParent = new GAV( "org.kie.guvnor",
-                                        "guvnor-m2repo-editor-backend-parent",
-                                        "0.0.1-SNAPSHOT" );
-        InputStream is = this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-pom.xml" );
-        repo.deployPom( is,
-                        gavBackendParent );
+        GAV gavBackendParent = new GAV("org.kie.guvnor",
+                                       "guvnor-m2repo-editor-backend-parent",
+                                       "0.0.1-SNAPSHOT");
+        InputStream is = this.getClass().getResourceAsStream("guvnor-m2repo-editor-backend-test-pom.xml");
+        repo.deployPom(is,
+                       gavBackendParent);
 
-        assertFilesCount( null, null, null, false, 3 );
+        assertFilesCount(null,
+                         null,
+                         null,
+                         false,
+                         3);
     }
 
     @Test
     public void testListFilesWhenNoneExist() throws Exception {
-        assertFilesCount( null,
-                          null,
-                          JarListPageRequest.COLUMN_GAV,
-                          false,
-                          0 );
+        assertFilesCount(null,
+                         null,
+                         JarListPageRequest.COLUMN_GAV,
+                         false,
+                         0);
     }
 
     @Test
     public void testListFilesWithPageSize() throws Exception {
         //Deploy 2 files (equating to 4 files)
-        deployArtifact( gavBackend1 );
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend1);
+        deployArtifact(gavBackend2);
 
-        final JarListPageRequest request = new JarListPageRequest( 0,
-                                                                   10,
-                                                                   null,
-                                                                   null,
-                                                                   null,
-                                                                   true );
-        final PageResponse<JarListPageRow> response = service.listArtifacts( request );
-        assertEquals( 4,
-                      response.getPageRowList().size() );
+        final JarListPageRequest request = new JarListPageRequest(0,
+                                                                  10,
+                                                                  null,
+                                                                  null,
+                                                                  null,
+                                                                  true);
+        final PageResponse<JarListPageRow> response = service.listArtifacts(request);
+        assertEquals(4,
+                     response.getPageRowList().size());
     }
 
     @Test
     public void testListFilesWithStartBeyondMaximum() throws Exception {
         //Deploy 2 files (equating to 4 files)
-        deployArtifact( gavBackend1 );
-        deployArtifact( gavBackend2 );
+        deployArtifact(gavBackend1);
+        deployArtifact(gavBackend2);
 
-        final JarListPageRequest request = new JarListPageRequest( 10,
-                                                                   10,
-                                                                   null,
-                                                                   null,
-                                                                   null,
-                                                                   true );
-        final PageResponse<JarListPageRow> response = service.listArtifacts( request );
-        assertEquals( 0,
-                      response.getPageRowList().size() );
+        final JarListPageRequest request = new JarListPageRequest(10,
+                                                                  10,
+                                                                  null,
+                                                                  null,
+                                                                  null,
+                                                                  true);
+        final PageResponse<JarListPageRow> response = service.listArtifacts(request);
+        assertEquals(0,
+                     response.getPageRowList().size());
     }
 
     @Test
     public void testCheckArtifactExistsReturnsTrueForExistingArtifact() {
-        deployArtifact( gavBackend );
-        assertTrue( repo.containsArtifact( gavBackend ) );
+        deployArtifact(gavBackend);
+        assertTrue(repo.containsArtifact(gavBackend));
     }
 
     @Test
     public void testCheckArtifactExistsReturnsFalseForNonExistingArtifact() {
-        assertFalse( repo.containsArtifact( new GAV( "org.guvnor:non-existing-jar:1.0.Final" ) ) );
+        assertFalse(repo.containsArtifact(new GAV("org.guvnor:non-existing-jar:1.0.Final")));
     }
 
     @Test
     public void testGetPomTextRejectsTraversingPaths() {
-        service.getPomText( "dir/name.jar" );
-        service.getPomText( "dir/name.kjar" );
-        service.getPomText( "dir/name.pom" );
+        service.getPomText("dir/name.jar");
+        service.getPomText("dir/name.kjar");
+        service.getPomText("dir/name.pom");
 
-        exception.expect( RuntimeException.class );
-        service.getPomText( "path/../file.pom" );
+        exception.expect(RuntimeException.class);
+        service.getPomText("path/../file.pom");
     }
 
     @Test
     public void testLoadGAVFromJarRejectsTraversingPaths() {
-        exception.expect( RuntimeException.class );
-        service.loadGAVFromJar( "path/../file.jar" );
+        exception.expect(RuntimeException.class);
+        service.loadGAVFromJar("path/../file.jar");
     }
 
-    private PageResponse<JarListPageRow> assertFilesCount( final String filters,
-                                                           final List<String> fileFormats,
-                                                           final String dataSourceName,
-                                                           final boolean isAscending,
-                                                           final int filesCount ) {
-        final JarListPageRequest request = new JarListPageRequest( 0,
-                                                                   null,
-                                                                   filters,
-                                                                   fileFormats,
-                                                                   dataSourceName,
-                                                                   isAscending );
-        final PageResponse<JarListPageRow> response = service.listArtifacts( request );
-        assertEquals( filesCount,
-                      response.getPageRowList().size() );
+    private PageResponse<JarListPageRow> assertFilesCount(final String filters,
+                                                          final List<String> fileFormats,
+                                                          final String dataSourceName,
+                                                          final boolean isAscending,
+                                                          final int filesCount) {
+        final JarListPageRequest request = new JarListPageRequest(0,
+                                                                  null,
+                                                                  filters,
+                                                                  fileFormats,
+                                                                  dataSourceName,
+                                                                  isAscending);
+        final PageResponse<JarListPageRow> response = service.listArtifacts(request);
+        assertEquals(filesCount,
+                     response.getPageRowList().size());
         return response;
     }
 
-    private void deployArtifact( GAV gav ) {
+    private void deployArtifact(GAV gav) {
         //This installs a JAR and a POM
-        InputStream is = this.getClass().getResourceAsStream( "guvnor-m2repo-editor-backend-test-without-pom.jar" );
-        repo.deployArtifact( is,
-                             gav,
-                             false );
+        InputStream is = this.getClass().getResourceAsStream("guvnor-m2repo-editor-backend-test-without-pom.jar");
+        repo.deployArtifact(is,
+                            gav,
+                            false);
     }
 
     //Create a mock FileItem setting an InputStream to test with
@@ -660,8 +692,8 @@ public class M2RepositoryServiceImplTest {
         private final String fileName;
         private final InputStream fileStream;
 
-        MockFileItem( final String fileName,
-                      final InputStream fileStream ) {
+        MockFileItem(final String fileName,
+                     final InputStream fileStream) {
             this.fileName = fileName;
             this.fileStream = fileStream;
         }
@@ -698,7 +730,7 @@ public class M2RepositoryServiceImplTest {
         }
 
         @Override
-        public String getString( String encoding ) throws UnsupportedEncodingException {
+        public String getString(String encoding) throws UnsupportedEncodingException {
             return null;
         }
 
@@ -708,7 +740,7 @@ public class M2RepositoryServiceImplTest {
         }
 
         @Override
-        public void write( File file ) throws Exception {
+        public void write(File file) throws Exception {
         }
 
         @Override
@@ -721,7 +753,7 @@ public class M2RepositoryServiceImplTest {
         }
 
         @Override
-        public void setFieldName( String name ) {
+        public void setFieldName(String name) {
         }
 
         @Override
@@ -730,7 +762,7 @@ public class M2RepositoryServiceImplTest {
         }
 
         @Override
-        public void setFormField( boolean state ) {
+        public void setFormField(boolean state) {
         }
 
         @Override
@@ -744,9 +776,7 @@ public class M2RepositoryServiceImplTest {
         }
 
         @Override
-        public void setHeaders( FileItemHeaders fileItemHeaders ) {
+        public void setHeaders(FileItemHeaders fileItemHeaders) {
         }
-
     }
-
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/resources/i18n/M2Constants.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/resources/i18n/M2Constants.java
@@ -24,6 +24,18 @@ public class M2Constants {
     @TranslationKey(defaultValue = "Artifact Repository")
     public static final String ArtifactRepositoryPreference_Label = "ArtifactRepositoryPreference.Label";
 
-    @TranslationKey(defaultValue = "M2 repository directory")
-    public static final String ArtifactRepositoryPreference_DefaultM2RepoDir = "ArtifactRepositoryPreference.DefaultM2RepoDir";
+    @TranslationKey(defaultValue = "Global M2 repository directory")
+    public static final String ArtifactRepositoryPreference_GlobalM2RepoDir = "ArtifactRepositoryPreference.GlobalM2RepoDir";
+
+    @TranslationKey(defaultValue = "Is Global M2 repository directory enabled?")
+    public static final String ArtifactRepositoryPreference_GlobalM2RepoDirEnabled = "ArtifactRepositoryPreference.GlobalM2RepoDirEnabled";
+
+    @TranslationKey(defaultValue = "Workspace M2 repository directory")
+    public static final String ArtifactRepositoryPreference_WorkspaceM2RepoDir = "ArtifactRepositoryPreference.WorkspaceM2RepoDir";
+
+    @TranslationKey(defaultValue = "Is Workspace M2 repository directory enabled?")
+    public static final String ArtifactRepositoryPreference_WorkspaceM2RepoDirEnabled = "ArtifactRepositoryPreference.WorkspaceM2RepoDirEnabled";
+
+    @TranslationKey(defaultValue = "Is Distribution Management repository enabled?")
+    public static final String ArtifactRepositoryPreference_DistributionManagementM2RepoDirEnabled = "ArtifactRepositoryPreference.DistributionManagementM2RepoDirEnabled";
 }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/client/resources/i18n/M2Constants.properties
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/resources/org/guvnor/m2repo/client/resources/i18n/M2Constants.properties
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 #
-
-
-
 ArtifactRepositoryPreference.Label=Artifact Repository
-ArtifactRepositoryPreference.DefaultM2RepoDir=M2 repository directory
+ArtifactRepositoryPreference.GlobalM2RepoDir=Global M2 repository directory
+ArtifactRepositoryPreference.GlobalM2RepoDirEnabled=Is Global M2 repository directory enabled?
+ArtifactRepositoryPreference.WorkspaceM2RepoDir=Workspace M2 repository directory
+ArtifactRepositoryPreference.WorkspaceM2RepoDirEnabled=Is Workspace M2 repository directory enabled?
+ArtifactRepositoryPreference.DistributionManagementM2RepoDirEnabled=Is Distribution Management repository enabled?

--- a/guvnor-project/guvnor-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/POMServiceImpl.java
+++ b/guvnor-project/guvnor-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/POMServiceImpl.java
@@ -31,6 +31,7 @@ import org.guvnor.common.services.shared.metadata.MetadataService;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.guvnor.m2repo.service.M2RepoService;
 import org.jboss.errai.bus.server.annotations.Service;
+import org.uberfire.backend.server.cdi.workspace.WorkspaceScoped;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.io.IOService;
@@ -38,7 +39,7 @@ import org.uberfire.java.nio.file.FileAlreadyExistsException;
 import org.uberfire.java.nio.file.FileSystem;
 
 @Service
-@ApplicationScoped
+@WorkspaceScoped
 public class POMServiceImpl
         implements POMService {
 

--- a/guvnor-project/guvnor-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/ProjectRepositoryResolverImpl.java
+++ b/guvnor-project/guvnor-project-backend/src/main/java/org/guvnor/common/services/project/backend/server/ProjectRepositoryResolverImpl.java
@@ -64,6 +64,7 @@ import org.jboss.errai.bus.server.annotations.Service;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.annotations.Customizable;
+import org.uberfire.backend.server.cdi.workspace.WorkspaceScoped;
 import org.uberfire.backend.server.util.Paths;
 import org.uberfire.backend.vfs.Path;
 import org.uberfire.preferences.shared.impl.PreferenceScopeResolutionStrategyInfo;
@@ -73,7 +74,7 @@ import org.uberfire.java.nio.file.NoSuchFileException;
 import static org.guvnor.common.services.project.backend.server.MavenLocalRepositoryUtils.*;
 
 @Service
-@ApplicationScoped
+@WorkspaceScoped
 public class ProjectRepositoryResolverImpl
         implements ProjectRepositoryResolver {
 

--- a/guvnor-project/guvnor-project-builder/pom.xml
+++ b/guvnor-project/guvnor-project-builder/pom.xml
@@ -79,6 +79,12 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+      <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- Needed by kie-api if KieModules are to be built -->
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -89,6 +95,17 @@
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-backend-server</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-cdi</artifactId>
+    </dependency>
+
 
   </dependencies>
 

--- a/guvnor-project/guvnor-project-builder/src/main/java/org/guvnor/common/services/builder/IncrementalBuilderExecutorManager.java
+++ b/guvnor-project/guvnor-project-builder/src/main/java/org/guvnor/common/services/builder/IncrementalBuilderExecutorManager.java
@@ -16,13 +16,13 @@
 package org.guvnor.common.services.builder;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.ejb.Asynchronous;
 import javax.ejb.Singleton;
 import javax.ejb.Startup;
 import javax.ejb.TransactionAttribute;
+import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
 
@@ -32,9 +32,8 @@ import org.guvnor.common.services.project.builder.service.BuildService;
 import org.guvnor.common.services.project.model.Project;
 import org.guvnor.common.services.project.service.ProjectService;
 import org.uberfire.commons.async.DescriptiveRunnable;
-import org.uberfire.commons.async.DescriptiveThreadFactory;
 
-import static javax.ejb.TransactionAttributeType.*;
+import static javax.ejb.TransactionAttributeType.NOT_SUPPORTED;
 
 @Singleton
 @Startup
@@ -53,71 +52,76 @@ public class IncrementalBuilderExecutorManager {
     @Inject
     private Event<IncrementalBuildResults> incrementalBuildResultsEvent;
 
-    private AtomicBoolean useExecService = new AtomicBoolean( false );
+    @Inject
+    private ManagedExecutorService managedExecutorService;
+
+    private AtomicBoolean useExecService = new AtomicBoolean(false);
     private ExecutorService executorService = null;
 
     @Asynchronous
-    public void execute( final AsyncIncrementalBuilder incrementalBuilder ) {
-        if ( useExecService.get() ) {
-            getExecutorService().execute( new DescriptiveRunnable() {
+    public void execute(final AsyncIncrementalBuilder incrementalBuilder) {
+        if (useExecService.get()) {
+            getExecutorService().execute(new DescriptiveRunnable() {
                 @Override
                 public void run() {
-                    incrementalBuilder.execute( projectService,
-                                                buildService,
-                                                incrementalBuildResultsEvent,
-                                                buildResultsEvent );
+                    incrementalBuilder.execute(projectService,
+                                               buildService,
+                                               incrementalBuildResultsEvent,
+                                               buildResultsEvent);
                 }
 
                 @Override
                 public String getDescription() {
                     return incrementalBuilder.getDescription();
                 }
-            } );
+            });
         } else {
-            incrementalBuilder.execute( projectService,
-                                        buildService,
-                                        incrementalBuildResultsEvent,
-                                        buildResultsEvent );
+            incrementalBuilder.execute(projectService,
+                                       buildService,
+                                       incrementalBuildResultsEvent,
+                                       buildResultsEvent);
         }
     }
 
     //Public so we can set the ExecutorService for tests not within guvnor
-    public void setExecutorService( final ExecutorService executorService ) {
+    public void setExecutorService(final ExecutorService executorService) {
         this.executorService = executorService;
-        this.useExecService.set( true );
+        this.useExecService.set(true);
     }
 
     private ExecutorService getExecutorService() {
-        if ( executorService == null ) {
-            executorService = Executors.newCachedThreadPool( new DescriptiveThreadFactory() );
+        if (executorService == null) {
+            executorService = managedExecutorService;
         }
         return executorService;
     }
 
-    public void setServices( final ProjectService projectService,
-                             final BuildService buildService,
-                             final Event<BuildResults> buildResultsEvent,
-                             final Event<IncrementalBuildResults> incrementalBuildResultsEvent ) {
+    public void setServices(final ProjectService projectService,
+                            final BuildService buildService,
+                            final Event<BuildResults> buildResultsEvent,
+                            final Event<IncrementalBuildResults> incrementalBuildResultsEvent) {
         this.projectService = projectService;
         this.buildService = buildService;
         this.buildResultsEvent = buildResultsEvent;
         this.incrementalBuildResultsEvent = incrementalBuildResultsEvent;
-        this.useExecService.set( true );
+        this.useExecService.set(true);
     }
 
     public void shutdown() {
-        if ( useExecService.get() && executorService != null ) {
+        if (useExecService.get() && executorService != null) {
             executorService.shutdown(); // Disable new tasks from being submitted
             try {
                 // Wait a while for existing tasks to terminate
-                if ( !executorService.awaitTermination( 60, TimeUnit.SECONDS ) ) {
+                if (!executorService.awaitTermination(60,
+                                                      TimeUnit.SECONDS)) {
                     executorService.shutdownNow(); // Cancel currently executing tasks
                     // Wait a while for tasks to respond to being cancelled
-                    if ( !executorService.awaitTermination( 60, TimeUnit.SECONDS ) ) {
-                        System.err.println( "Pool did not terminate" );
+                    if (!executorService.awaitTermination(60,
+                                                          TimeUnit.SECONDS)) {
+                        System.err.println("Pool did not terminate");
                     }
                 }
-            } catch ( InterruptedException ie ) {
+            } catch (InterruptedException ie) {
                 // (Re-)Cancel if current thread also interrupted
                 executorService.shutdownNow();
                 // Preserve interrupt status

--- a/guvnor-project/guvnor-project-builder/src/main/java/org/guvnor/common/services/builder/IncrementalBuilderExecutorManagerFactoryImpl.java
+++ b/guvnor-project/guvnor-project-builder/src/main/java/org/guvnor/common/services/builder/IncrementalBuilderExecutorManagerFactoryImpl.java
@@ -15,6 +15,7 @@
 
 package org.guvnor.common.services.builder;
 
+import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
 import javax.inject.Inject;
@@ -47,6 +48,9 @@ public class IncrementalBuilderExecutorManagerFactoryImpl implements Incremental
     @Inject
     private Event<IncrementalBuildResults> incrementalBuildResultsEvent;
 
+    @Inject
+    private ManagedExecutorService managedExecutorService;
+
     private IncrementalBuilderExecutorManager executorManager = null;
 
     @Override
@@ -75,6 +79,7 @@ public class IncrementalBuilderExecutorManagerFactoryImpl implements Incremental
                                              buildService,
                                              buildResultsEvent,
                                              incrementalBuildResultsEvent );
+                executorManager.setExecutorService(this.managedExecutorService);
             } else {
                 executorManager = _executorManager;
             }

--- a/guvnor-rest/guvnor-rest-backend/pom.xml
+++ b/guvnor-rest/guvnor-rest-backend/pom.xml
@@ -97,6 +97,10 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+      <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
+    </dependency>
 
     <!-- TEST: reflection -->
     <dependency>

--- a/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
+++ b/guvnor-rest/guvnor-rest-backend/src/main/java/org/guvnor/rest/backend/JobRequestScheduler.java
@@ -17,9 +17,7 @@ package org.guvnor.rest.backend;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.guvnor.rest.backend.cmd.AbstractJobCommand.JOB_REQUEST_KEY;
-
+import javax.enterprise.concurrent.ManagedExecutorService;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -54,7 +52,8 @@ import org.guvnor.rest.client.TestProjectRequest;
 import org.guvnor.rest.client.UpdateOrganizationalUnitRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.uberfire.commons.async.SimpleAsyncExecutorService;
+
+import static org.guvnor.rest.backend.cmd.AbstractJobCommand.JOB_REQUEST_KEY;
 
 /**
  * Utility class observing requests for various functions of the REST service
@@ -63,6 +62,9 @@ import org.uberfire.commons.async.SimpleAsyncExecutorService;
 public class JobRequestScheduler {
 
     private static final Logger logger = LoggerFactory.getLogger( JobRequestScheduler.class );
+
+    @Inject
+    private ManagedExecutorService managedExecutorService;
 
     @Inject
     private JobResultManager jobResultManager;
@@ -176,7 +178,7 @@ public class JobRequestScheduler {
 
         scheduleJob(jobRequest, new RemoveOrgUnitCmd(jobRequestHelper, jobResultManager, params));
     }
-        
+
     protected Map<String, Object> getContext(JobRequest jobRequest) {
         final Map<String, Object> params = new HashMap<String, Object>();
         params.put(JOB_REQUEST_KEY, jobRequest);
@@ -189,7 +191,7 @@ public class JobRequestScheduler {
         jobRequest.setStatus(JobStatus.APPROVED);
         logger.debug("Scheduling job request with id: {} and command class: {}",
                 jobRequest.getJobId(), command.getClass().getName() );
-        SimpleAsyncExecutorService.getDefaultInstance().execute(command);
+        this.managedExecutorService.execute(command);
     }
 
 }


### PR DESCRIPTION
- Improvements on M2 Repositories. Now you can configure some of them through Preference API
- Some beans converted into WorkspaceScoped beans (https://github.com/AppFormer/uberfire/pull/718)
- It also exist a WorkspaceScoped Repository but it's disabled by default because other devs needs to be done before It can be used, but It is basically a repository that is going to be used by a Workspace to store artifacts, and those artifacts can only be seen my that workspace.