### PR TITLE
Enable findbugs.failOnViolation

### DIFF
--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/archive/ArchiveServlet.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/archive/ArchiveServlet.java
@@ -50,7 +50,7 @@ public class ArchiveServlet
                 String downLoadFileName = uri.substring( index );
                 if ( downLoadFileName.startsWith( "/" ) ) downLoadFileName = downLoadFileName.substring( 1 );
                 if ( downLoadFileName.endsWith( "/" ) ) downLoadFileName = downLoadFileName.substring( 0, downLoadFileName.length() - 1 );
-                downLoadFileName.replaceAll( "/", "_" );
+                downLoadFileName = downLoadFileName.replaceAll( "/", "_" );
 
                 final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/fileexplorer/FileExplorerPresenter.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/fileexplorer/FileExplorerPresenter.java
@@ -202,7 +202,7 @@ public class FileExplorerPresenter
         }
         if ( repositories.containsKey( repository.getAlias() ) ) {
             view.removeRepository( repository );
-            repositories.remove( repository );
+            repositories.remove( repository.getAlias() );
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
   <properties>
     <!-- Surefire 2.18.1 sometimes fails as described in SUREFIRE-859. -->
     <version.surefire.plugin>2.19.1</version.surefire.plugin>
+    <findbugs.failOnViolation>true</findbugs.failOnViolation>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Enable findbugs-maven-plugin to fail the build when serious bug has been identified.
At the same time fixing 2 issues identified by the plugin.

(The configuration of the plugin can be found in [droolsjbpm-build-bootstrap/pom.xml](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/pom.xml#L1165-L1182) and has been already fine-tuned by QE to only fail the build in cases where it's almost certain there's a bug (as you can see in the issues fixed).

@manstis wdyt?