### PR TITLE
AF-546: Reduce startup time of AppFormer apps and workbenches

### DIFF
--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/M2RepoEditorEntryPoint.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-client/src/main/java/org/guvnor/m2repo/client/M2RepoEditorEntryPoint.java
@@ -15,8 +15,9 @@
  */
 package org.guvnor.m2repo.client;
 
+import javax.annotation.PostConstruct;
+
 import org.guvnor.m2repo.client.resources.M2RepoEditorResources;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ui.shared.api.annotations.Bundle;
 
@@ -24,7 +25,7 @@ import org.jboss.errai.ui.shared.api.annotations.Bundle;
 @Bundle( "resources/i18n/M2Constants.properties" )
 public class M2RepoEditorEntryPoint {
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         M2RepoEditorResources.INSTANCE.CSS().ensureInjected();
     }

--- a/guvnor-organizationalunit-manager/src/main/java/org/guvnor/organizationalunit/manager/client/OrganizationalUnitManagerEntryPoint.java
+++ b/guvnor-organizationalunit-manager/src/main/java/org/guvnor/organizationalunit/manager/client/OrganizationalUnitManagerEntryPoint.java
@@ -16,9 +16,10 @@
 
 package org.guvnor.organizationalunit.manager.client;
 
-import org.jboss.errai.ioc.client.api.AfterInitialization;
-import org.jboss.errai.ioc.client.api.EntryPoint;
+import javax.annotation.PostConstruct;
+
 import org.guvnor.organizationalunit.manager.client.resources.OrganizationalUnitManagerResources;
+import org.jboss.errai.ioc.client.api.EntryPoint;
 
 /**
  * Entry Point for Organizational Manager editor
@@ -26,7 +27,7 @@ import org.guvnor.organizationalunit.manager.client.resources.OrganizationalUnit
 @EntryPoint
 public class OrganizationalUnitManagerEntryPoint {
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         OrganizationalUnitManagerResources.INSTANCE.CSS().ensureInjected();
     }

--- a/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/ProjectEntryPoint.java
+++ b/guvnor-project/guvnor-project-client/src/main/java/org/guvnor/common/services/project/client/ProjectEntryPoint.java
@@ -16,10 +16,10 @@
 
 package org.guvnor.common.services.project.client;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 
 import org.guvnor.common.services.project.client.preferences.ProjectScopedResolutionStrategySupplier;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.jboss.errai.ui.shared.api.annotations.Bundle;
 import org.uberfire.ext.preferences.client.admin.page.AdminPage;
@@ -39,7 +39,7 @@ public class ProjectEntryPoint {
         this.projectScopedResolutionStrategySupplier = projectScopedResolutionStrategySupplier;
     }
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         setupProjectAdminPage();
     }

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/StructureEntryPoint.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/StructureEntryPoint.java
@@ -15,8 +15,9 @@
  */
 package org.guvnor.structure.client;
 
+import javax.annotation.PostConstruct;
+
 import org.guvnor.structure.client.resources.NavigatorResources;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.jboss.errai.ioc.client.api.EntryPoint;
 import org.uberfire.client.views.pfly.sys.PatternFlyBootstrapper;
 
@@ -26,7 +27,7 @@ import org.uberfire.client.views.pfly.sys.PatternFlyBootstrapper;
 @EntryPoint
 public class StructureEntryPoint {
 
-    @AfterInitialization
+    @PostConstruct
     public void startApp() {
         //Ensure CSS has been loaded
         NavigatorResources.INSTANCE.css().ensureInjected();

--- a/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenter.java
+++ b/guvnor-structure/guvnor-structure-client/src/main/java/org/guvnor/structure/client/editors/repository/clone/CloneRepositoryPresenter.java
@@ -16,9 +16,12 @@
 
 package org.guvnor.structure.client.editors.repository.clone;
 
+import static org.guvnor.structure.security.RepositoryFeatures.CONFIGURE_REPOSITORY;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Observes;
@@ -38,14 +41,11 @@ import org.jboss.errai.bus.client.api.messaging.Message;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.common.client.api.ErrorCallback;
 import org.jboss.errai.common.client.api.RemoteCallback;
-import org.jboss.errai.ioc.client.api.AfterInitialization;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 import org.uberfire.rpc.SessionInfo;
 import org.uberfire.security.authz.AuthorizationManager;
 import org.uberfire.util.URIUtil;
-
-import static org.guvnor.structure.security.RepositoryFeatures.*;
 
 @Dependent
 public class CloneRepositoryPresenter implements CloneRepositoryView.Presenter {
@@ -89,10 +89,6 @@ public class CloneRepositoryPresenter implements CloneRepositoryView.Presenter {
         view.init( this,
                    isOuMandatory() );
         setAssetsManagementGrant();
-    }
-
-    @AfterInitialization
-    public void load() {
         populateOrganizationalUnits();
     }
 


### PR DESCRIPTION
Replace @AfterInitialization methods with @PostConstruct so that
startup RPC calls can be grouped into a single payload.