### PR TITLE
AF-547: VFS commit batch broken

### DIFF
--- a/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/model/GeneratedInfoHolder.java
+++ b/guvnor-services/guvnor-services-api/src/main/java/org/guvnor/common/services/shared/metadata/model/GeneratedInfoHolder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.shared.metadata.model;
+
+import org.jboss.errai.common.client.api.annotations.Portable;
+
+@Portable
+public class GeneratedInfoHolder {
+
+    private boolean generated;
+
+    public GeneratedInfoHolder() {
+    }
+
+    public GeneratedInfoHolder(boolean generated) {
+        this.generated = generated;
+    }
+
+    public boolean isGenerated() {
+        return generated;
+    }
+
+    public void setGenerated(boolean generated) {
+        this.generated = generated;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GeneratedInfoHolder that = (GeneratedInfoHolder) o;
+
+        return generated == that.generated;
+    }
+
+    @Override
+    public int hashCode() {
+        return (generated ? 1 : 0);
+    }
+}

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
@@ -29,11 +29,13 @@ import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionAttributes;
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionAttributesUtil;
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionView;
+import org.guvnor.common.services.backend.metadata.attribute.GeneratedAttributesUtil;
 import org.guvnor.common.services.backend.metadata.attribute.GeneratedAttributesView;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaAttributes;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaAttributesUtil;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaView;
 import org.guvnor.common.services.shared.metadata.model.DiscussionRecord;
+import org.guvnor.common.services.shared.metadata.model.GeneratedInfoHolder;
 import org.guvnor.common.services.shared.metadata.model.Metadata;
 import org.jboss.errai.bus.server.annotations.Service;
 import org.uberfire.backend.server.util.Paths;
@@ -48,8 +50,8 @@ import org.uberfire.java.nio.file.NoSuchFileException;
 import org.uberfire.java.nio.file.attribute.FileTime;
 import org.uberfire.rpc.SessionInfo;
 
-import static java.util.Collections.*;
-import static org.uberfire.commons.validation.PortablePreconditions.*;
+import static java.util.Collections.emptyList;
+import static org.uberfire.commons.validation.PortablePreconditions.checkNotNull;
 
 @Service
 @ApplicationScoped
@@ -64,51 +66,55 @@ public class MetadataServiceImpl
     }
 
     @Inject
-    public MetadataServiceImpl( @Named("ioStrategy") IOService ioService,
-                                @Named("configIO") IOService configIOService,
-                                SessionInfo sessionInfo ) {
+    public MetadataServiceImpl(@Named("ioStrategy") IOService ioService,
+                               @Named("configIO") IOService configIOService,
+                               SessionInfo sessionInfo) {
         this.ioService = ioService;
         this.configIOService = configIOService;
         this.sessionInfo = sessionInfo;
     }
 
     @Override
-    public Metadata getMetadata( final Path pathToResource ) {
-        return getMetadata( Paths.convert( pathToResource ) );
+    public Metadata getMetadata(final Path pathToResource) {
+        return getMetadata(Paths.convert(pathToResource));
     }
 
     @Override
-    public Metadata getMetadata( org.uberfire.java.nio.file.Path path ) {
+    public Metadata getMetadata(org.uberfire.java.nio.file.Path path) {
 
         try {
-            return new MetadataCreator( path,
-                                        configIOService,
-                                        sessionInfo,
-                                        ioService.getFileAttributeView( path, DublinCoreView.class ),
-                                        ioService.getFileAttributeView( path, DiscussionView.class ),
-                                        ioService.getFileAttributeView( path, OtherMetaView.class ),
-                                        ioService.getFileAttributeView( path, VersionAttributeView.class ),
-                                        ioService.getFileAttributeView( path, GeneratedAttributesView.class ) ).create();
-
-        } catch ( Exception e ) {
-            throw ExceptionUtilities.handleException( e );
+            return new MetadataCreator(path,
+                                       configIOService,
+                                       sessionInfo,
+                                       ioService.getFileAttributeView(path,
+                                                                      DublinCoreView.class),
+                                       ioService.getFileAttributeView(path,
+                                                                      DiscussionView.class),
+                                       ioService.getFileAttributeView(path,
+                                                                      OtherMetaView.class),
+                                       ioService.getFileAttributeView(path,
+                                                                      VersionAttributeView.class),
+                                       ioService.getFileAttributeView(path,
+                                                                      GeneratedAttributesView.class)).create();
+        } catch (Exception e) {
+            throw ExceptionUtilities.handleException(e);
         }
     }
 
     @Override
-    public List<String> getTags( final Path resource ) {
-        checkNotNull( "resource",
-                      resource );
-        return getTags( Paths.convert( resource ) );
+    public List<String> getTags(final Path resource) {
+        checkNotNull("resource",
+                     resource);
+        return getTags(Paths.convert(resource));
     }
 
     @Override
-    public List<String> getTags( final org.uberfire.java.nio.file.Path resource ) {
-        checkNotNull( "resource",
-                      resource );
-        final OtherMetaView otherMetaView = ioService.getFileAttributeView( resource,
-                                                                            OtherMetaView.class );
-        if ( otherMetaView != null ) {
+    public List<String> getTags(final org.uberfire.java.nio.file.Path resource) {
+        checkNotNull("resource",
+                     resource);
+        final OtherMetaView otherMetaView = ioService.getFileAttributeView(resource,
+                                                                           OtherMetaView.class);
+        if (otherMetaView != null) {
             return otherMetaView.readAttributes().tags();
         } else {
             return Collections.emptyList();
@@ -116,18 +122,21 @@ public class MetadataServiceImpl
     }
 
     @Override
-    public Map<String, Object> configAttrs( final Map<String, Object> _attrs,
-                                            final Metadata metadata ) {
+    public Map<String, Object> configAttrs(final Map<String, Object> _attrs,
+                                           final Metadata metadata) {
         try {
-            checkNotNull( "_attrs", _attrs );
-            checkNotNull( "metadata", metadata );
+            checkNotNull("_attrs",
+                         _attrs);
+            checkNotNull("metadata",
+                         metadata);
 
-            Map<String, Object> attrs = BasicFileAttributesUtil.cleanup( _attrs );
-            attrs = DublinCoreAttributesUtil.cleanup( attrs );
-            attrs = DiscussionAttributesUtil.cleanup( attrs );
-            attrs = OtherMetaAttributesUtil.cleanup( attrs );
+            Map<String, Object> attrs = BasicFileAttributesUtil.cleanup(_attrs);
+            attrs = DublinCoreAttributesUtil.cleanup(attrs);
+            attrs = DiscussionAttributesUtil.cleanup(attrs);
+            attrs = OtherMetaAttributesUtil.cleanup(attrs);
+            attrs = GeneratedAttributesUtil.cleanup(attrs);
 
-            attrs.putAll( DiscussionAttributesUtil.toMap(
+            attrs.putAll(DiscussionAttributesUtil.toMap(
                     new DiscussionAttributes() {
                         @Override
                         public List<DiscussionRecord> discussion() {
@@ -178,9 +187,10 @@ public class MetadataServiceImpl
                         public Object fileKey() {
                             return null;
                         }
-                    }, "*" ) );
+                    },
+                    "*"));
 
-            attrs.putAll( OtherMetaAttributesUtil.toMap(
+            attrs.putAll(OtherMetaAttributesUtil.toMap(
                     new OtherMetaAttributes() {
                         @Override
                         public List<String> tags() {
@@ -231,9 +241,10 @@ public class MetadataServiceImpl
                         public Object fileKey() {
                             return null;
                         }
-                    }, "*" ) );
+                    },
+                    "*"));
 
-            attrs.putAll( DublinCoreAttributesUtil.toMap(
+            attrs.putAll(DublinCoreAttributesUtil.toMap(
                     new DublinCoreAttributes() {
 
                         @Override
@@ -248,15 +259,15 @@ public class MetadataServiceImpl
 
                         @Override
                         public List<String> subjects() {
-                            return new ArrayList<String>( 1 ) {{
-                                add( metadata.getSubject() );
+                            return new ArrayList<String>(1) {{
+                                add(metadata.getSubject());
                             }};
                         }
 
                         @Override
                         public List<String> descriptions() {
-                            return new ArrayList<String>( 1 ) {{
-                                add( metadata.getDescription() );
+                            return new ArrayList<String>(1) {{
+                                add(metadata.getDescription());
                             }};
                         }
 
@@ -272,8 +283,8 @@ public class MetadataServiceImpl
 
                         @Override
                         public List<String> types() {
-                            return new ArrayList<String>( 1 ) {{
-                                add( metadata.getType() );
+                            return new ArrayList<String>(1) {{
+                                add(metadata.getType());
                             }};
                         }
 
@@ -289,8 +300,8 @@ public class MetadataServiceImpl
 
                         @Override
                         public List<String> sources() {
-                            return new ArrayList<String>( 1 ) {{
-                                add( metadata.getExternalSource() );
+                            return new ArrayList<String>(1) {{
+                                add(metadata.getExternalSource());
                             }};
                         }
 
@@ -301,8 +312,8 @@ public class MetadataServiceImpl
 
                         @Override
                         public List<String> relations() {
-                            return new ArrayList<String>( 1 ) {{
-                                add( metadata.getExternalRelation() );
+                            return new ArrayList<String>(1) {{
+                                add(metadata.getExternalRelation());
                             }};
                         }
 
@@ -360,35 +371,36 @@ public class MetadataServiceImpl
                         public Object fileKey() {
                             return null;
                         }
-                    }, "*" ) );
+                    },
+                    "*"));
 
-            attrs.put( GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME, metadata.isGenerated() );
+            attrs.put(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME,
+                      new GeneratedInfoHolder(metadata.isGenerated()));
 
             return attrs;
-
-        } catch ( Exception e ) {
-            throw ExceptionUtilities.handleException( e );
+        } catch (Exception e) {
+            throw ExceptionUtilities.handleException(e);
         }
     }
 
     @Override
-    public Map<String, Object> setUpAttributes( final Path path,
-                                                final Metadata metadata ) {
+    public Map<String, Object> setUpAttributes(final Path path,
+                                               final Metadata metadata) {
         try {
             Map<String, Object> attributes;
             try {
-                attributes = ioService.readAttributes( Paths.convert( path ) );
-            } catch ( final NoSuchFileException ex ) {
+                attributes = ioService.readAttributes(Paths.convert(path));
+            } catch (final NoSuchFileException ex) {
                 attributes = new HashMap<String, Object>();
             }
-            if ( metadata != null ) {
-                attributes = configAttrs( attributes, metadata );
+            if (metadata != null) {
+                attributes = configAttrs(attributes,
+                                         metadata);
             }
 
-            return BasicFileAttributesUtil.cleanup( attributes );
-        } catch ( Exception e ) {
-            throw ExceptionUtilities.handleException( e );
+            return BasicFileAttributesUtil.cleanup(attributes);
+        } catch (Exception e) {
+            throw ExceptionUtilities.handleException(e);
         }
     }
-
 }

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesUtil.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesUtil.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.backend.metadata.attribute;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class GeneratedAttributesUtil {
+
+    private GeneratedAttributesUtil() {
+    }
+
+    public static Map<String, Object> cleanup(final Map<String, Object> _attrs) {
+        final Map<String, Object> attrs = new HashMap<>(_attrs);
+
+        attrs.replace(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME, null);
+
+        return attrs;
+    }
+}

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesView.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesView.java
@@ -18,6 +18,7 @@ package org.guvnor.common.services.backend.metadata.attribute;
 
 import java.util.Map;
 
+import org.guvnor.common.services.shared.metadata.model.GeneratedInfoHolder;
 import org.uberfire.java.nio.IOException;
 import org.uberfire.java.nio.base.AbstractBasicFileAttributeView;
 import org.uberfire.java.nio.base.AbstractPath;
@@ -34,13 +35,13 @@ public class GeneratedAttributesView extends AbstractBasicFileAttributeView<Abst
 
     private GeneratedFileAttributes generatedFileAttributes;
 
-    public GeneratedAttributesView( AbstractPath path ) {
-        super( path );
+    public GeneratedAttributesView(AbstractPath path) {
+        super(path);
 
         final boolean generated = extractGenerated();
 
-        final BasicFileAttributes fileAttrs = path.getFileSystem().provider().getFileAttributeView( path,
-                                                                                                    BasicFileAttributeView.class ).readAttributes();
+        final BasicFileAttributes fileAttrs = path.getFileSystem().provider().getFileAttributeView(path,
+                                                                                                   BasicFileAttributeView.class).readAttributes();
 
         this.generatedFileAttributes = new GeneratedFileAttributes() {
             @Override
@@ -98,7 +99,13 @@ public class GeneratedAttributesView extends AbstractBasicFileAttributeView<Abst
     private boolean extractGenerated() {
         final Map<String, Object> content = path.getAttrStorage().getContent();
 
-        return Boolean.parseBoolean( String.valueOf( content.get( GENERATED_ATTRIBUTE_NAME ) ) );
+        final Object generatedInfoHolderObject = content.get(GENERATED_ATTRIBUTE_NAME);
+
+        if (generatedInfoHolderObject instanceof GeneratedInfoHolder) {
+            return ((GeneratedInfoHolder) generatedInfoHolderObject).isGenerated();
+        }
+
+        return false;
     }
 
     @Override
@@ -108,7 +115,7 @@ public class GeneratedAttributesView extends AbstractBasicFileAttributeView<Abst
 
     @Override
     public Class[] viewTypes() {
-        return new Class[]{ GeneratedAttributesView.class };
+        return new Class[]{GeneratedAttributesView.class};
     }
 
     @Override

--- a/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesUtilTest.java
+++ b/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesUtilTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.backend.metadata.attribute;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.guvnor.common.services.shared.metadata.model.GeneratedInfoHolder;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GeneratedAttributesUtilTest {
+
+    @Test
+    public void cleanup() {
+        Map<String, Object> originalAttributeMap = new HashMap<String, Object>() {{
+            put(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME,
+                new GeneratedInfoHolder(true));
+            put("customAttribute",
+                "value");
+        }};
+
+        Map<String, Object> result = GeneratedAttributesUtil.cleanup(originalAttributeMap);
+
+        assertNull(result.get(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME));
+        assertNotNull(result.get("customAttribute"));
+    }
+}

--- a/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedFileAttributesViewTest.java
+++ b/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedFileAttributesViewTest.java
@@ -18,6 +18,7 @@ package org.guvnor.common.services.backend.metadata.attribute;
 
 import java.util.HashMap;
 
+import org.guvnor.common.services.shared.metadata.model.GeneratedInfoHolder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -37,37 +38,37 @@ public class GeneratedFileAttributesViewTest {
 
     @Test
     public void readAttributesGeneratedFile() {
-        readAttributesTest( true );
+        readAttributesTest(true);
     }
 
     @Test
     public void readAttributesNonGeneratedFile() {
-        readAttributesTest( false );
+        readAttributesTest(false);
     }
 
-    private void readAttributesTest( final boolean generated ) {
-        AttrsStorage attrsStorage = mock( AttrsStorage.class );
-        when( attrsStorage.getContent() ).thenReturn( new HashMap<String, Object>() {{
-            put( GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME,
-                 generated );
-        }} );
-        AbstractPath path = mock( AbstractPath.class );
-        when( path.getAttrStorage() ).thenReturn( attrsStorage );
+    private void readAttributesTest(final boolean generated) {
+        AttrsStorage attrsStorage = mock(AttrsStorage.class);
+        when(attrsStorage.getContent()).thenReturn(new HashMap<String, Object>() {{
+            put(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME,
+                new GeneratedInfoHolder(generated));
+        }});
+        AbstractPath path = mock(AbstractPath.class);
+        when(path.getAttrStorage()).thenReturn(attrsStorage);
 
-        FileSystemProvider fileSystemProvider = mock( FileSystemProvider.class );
-        BasicFileAttributeView basicFileAttributeView = mock( BasicFileAttributeView.class );
-        when( basicFileAttributeView.readAttributes() ).thenReturn( mock( BasicFileAttributes.class ) );
-        when( fileSystemProvider.getFileAttributeView( any(),
-                                                       any() ) ).thenReturn( basicFileAttributeView );
-        FileSystem fileSystem = mock( FileSystem.class );
-        when( fileSystem.provider() ).thenReturn( fileSystemProvider );
-        when( path.getFileSystem() ).thenReturn( fileSystem );
+        FileSystemProvider fileSystemProvider = mock(FileSystemProvider.class);
+        BasicFileAttributeView basicFileAttributeView = mock(BasicFileAttributeView.class);
+        when(basicFileAttributeView.readAttributes()).thenReturn(mock(BasicFileAttributes.class));
+        when(fileSystemProvider.getFileAttributeView(any(),
+                                                     any())).thenReturn(basicFileAttributeView);
+        FileSystem fileSystem = mock(FileSystem.class);
+        when(fileSystem.provider()).thenReturn(fileSystemProvider);
+        when(path.getFileSystem()).thenReturn(fileSystem);
 
-        GeneratedAttributesView view = new GeneratedAttributesView( path );
+        GeneratedAttributesView view = new GeneratedAttributesView(path);
 
         GeneratedFileAttributes generatedFileAttributes = view.readAttributes();
 
-        assertEquals( generated,
-                      generatedFileAttributes.isGenerated() );
+        assertEquals(generated,
+                     generatedFileAttributes.isGenerated());
     }
 }


### PR DESCRIPTION
Introduce a wrapper around 'generated' value to make sure such value is not recognized as a Serializable in org.uberfire.java.nio.base.dotfiles.DotFileUtils.buildDotFile.

@ederign Would you mind taking a look? Thanks