### PR TITLE
RHBPMS-4797 - Managed repository can't be created in business central…

### DIFF
--- a/guvnor-asset-mgmt/guvnor-asset-mgmt-project/src/main/filtered-resources/kjar/src/main/resources/ConfigureRepository.bpmn2
+++ b/guvnor-asset-mgmt/guvnor-asset-mgmt-project/src/main/filtered-resources/kjar/src/main/resources/ConfigureRepository.bpmn2
@@ -121,10 +121,6 @@
           <bpmn2:sourceRef>SourceBranchName</bpmn2:sourceRef>
           <bpmn2:targetRef>_4683E2EE-4471-42BC-8C04-3D7759FE30AD_OriginBranchNameInputX</bpmn2:targetRef>
         </bpmn2:dataInputAssociation>
-        <bpmn2:dataInputAssociation id="_qrgC6UsVEeSBnoD097BQOD">
-          <bpmn2:sourceRef>Owner</bpmn2:sourceRef>
-          <bpmn2:targetRef>_DF37F979-03D2-4369-9B70-8BC61144CD80_ownerInputX</bpmn2:targetRef>
-        </bpmn2:dataInputAssociation>
         <bpmn2:dataInputAssociation id="_qrgC6UsVEeSBnoD097BQOE">
           <bpmn2:sourceRef>Owner</bpmn2:sourceRef>
           <bpmn2:targetRef>_DF37F979-03D2-4369-9B70-8BC61144CD81_ownerInputX</bpmn2:targetRef>


### PR DESCRIPTION
… on WAS server

@krisv @markcoble here is a fix for the managed repo issue - caused by duplicated dataInputAssociation that pointed out to non existing data input