### PR TITLE
[UF-516]: WorkspaceScoped repositories

### DIFF
--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/preferences/ArtifactRepositoryPreference.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-api/src/main/java/org/guvnor/m2repo/preferences/ArtifactRepositoryPreference.java
@@ -17,6 +17,7 @@
 
 package org.guvnor.m2repo.preferences;
 
+import org.uberfire.preferences.shared.PropertyFormType;
 import org.uberfire.preferences.shared.annotations.Property;
 import org.uberfire.preferences.shared.annotations.WorkbenchPreference;
 import org.uberfire.preferences.shared.bean.BasePreference;
@@ -27,16 +28,16 @@ public class ArtifactRepositoryPreference implements BasePreference<ArtifactRepo
     @Property(bundleKey = "ArtifactRepositoryPreference.GlobalM2RepoDir")
     private String globalM2RepoDir;
 
-    @Property(bundleKey = "ArtifactRepositoryPreference.GlobalM2RepoDirEnabled")
+    @Property(bundleKey = "ArtifactRepositoryPreference.GlobalM2RepoDirEnabled", formType = PropertyFormType.BOOLEAN)
     private boolean globalM2RepoDirEnabled;
 
     @Property(bundleKey = "ArtifactRepositoryPreference.WorkspaceM2RepoDir")
     private String workspaceM2RepoDir;
 
-    @Property(bundleKey = "ArtifactRepositoryPreference.WorkspaceM2RepoDirEnabled")
+    @Property(bundleKey = "ArtifactRepositoryPreference.WorkspaceM2RepoDirEnabled", formType = PropertyFormType.BOOLEAN)
     private boolean workspaceM2RepoDirEnabled;
 
-    @Property(bundleKey = "ArtifactRepositoryPreference.DistributionManagementM2RepoDirEnabled")
+    @Property(bundleKey = "ArtifactRepositoryPreference.DistributionManagementM2RepoDirEnabled", formType = PropertyFormType.BOOLEAN)
     private boolean distributionManagementM2RepoDirEnabled;
 
     @Override

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/pom.xml
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/pom.xml
@@ -116,6 +116,11 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-backend-cdi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-maven-integration</artifactId>
     </dependency>
 
@@ -194,6 +199,11 @@
     <dependency>
       <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-testing-utils</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
@@ -50,7 +50,7 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.util.artifact.SubArtifact;
 import org.guvnor.common.services.project.model.GAV;
 import org.guvnor.m2repo.backend.server.repositories.ArtifactRepository;
-import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryFactory;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,13 +67,13 @@ public class GuvnorM2Repository {
 
     private final List<ArtifactRepository> repositories = new ArrayList<>();
     private final List<ArtifactRepository> pomRepositories = new ArrayList<>();
-    private ArtifactRepositoryFactory artifactRepositoryFactory;
+    private ArtifactRepositoryService artifactRepositoryFactory;
 
     public GuvnorM2Repository() {
     }
 
     @Inject
-    public GuvnorM2Repository(ArtifactRepositoryFactory factory) {
+    public GuvnorM2Repository(ArtifactRepositoryService factory) {
         this.artifactRepositoryFactory = factory;
     }
 
@@ -95,7 +95,7 @@ public class GuvnorM2Repository {
 
     public String getM2RepositoryRootDir(String repositoryName) {
 
-        String defaultName = ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME;
+        String defaultName = ArtifactRepositoryService.GLOBAL_M2_REPO_NAME;
         if (repositoryName != null && !repositoryName.isEmpty()) {
             defaultName = repositoryName;
         }
@@ -435,7 +435,7 @@ public class GuvnorM2Repository {
     }
 
     public String getPomText(final String path) {
-        ArtifactRepository repository = this.getArtifactRepository(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME);
+        ArtifactRepository repository = this.getArtifactRepository(ArtifactRepositoryService.GLOBAL_M2_REPO_NAME);
         final File file = new File(repository.getRootDir(),
                                    path);
 
@@ -487,7 +487,7 @@ public class GuvnorM2Repository {
     }
 
     public GAV loadGAVFromJar(final String jarPath) {
-        ArtifactRepository repository = this.getArtifactRepository(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME);
+        ArtifactRepository repository = this.getArtifactRepository(ArtifactRepositoryService.GLOBAL_M2_REPO_NAME);
         File zip = new File(repository.getRootDir(),
                             jarPath);
 

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/M2RepoServiceImpl.java
@@ -34,7 +34,7 @@ import org.appformer.maven.support.MinimalPomParser;
 import org.appformer.maven.support.PomModel;
 import org.eclipse.aether.artifact.Artifact;
 import org.guvnor.common.services.project.model.GAV;
-import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryFactory;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryService;
 import org.guvnor.m2repo.model.JarListPageRequest;
 import org.guvnor.m2repo.model.JarListPageRow;
 import org.guvnor.m2repo.service.M2RepoService;
@@ -195,7 +195,7 @@ public class M2RepoServiceImpl implements M2RepoService,
     String getJarPath(final String path,
                       final String separator) {
         //Strip "Repository" prefix
-        String pathToDir = repository.getM2RepositoryDir(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME);
+        String pathToDir = repository.getM2RepositoryDir(ArtifactRepositoryService.GLOBAL_M2_REPO_NAME);
         String jarPath = path.substring(pathToDir.length() + 1);
         //Replace OS-dependent file separators with HTTP path separators
         jarPath = jarPath.replaceAll("\\" + separator,
@@ -209,8 +209,8 @@ public class M2RepoServiceImpl implements M2RepoService,
         try {
             final String pom = getPomText(path);
             is = new ByteArrayInputStream(pom.getBytes(Charset.forName("UTF-8")));
-            final PomModel model = MinimalPomParser.parse( path,
-                                                           is);
+            final PomModel model = MinimalPomParser.parse(path,
+                                                          is);
             gav = new GAV(model.getReleaseId().getGroupId(),
                           model.getReleaseId().getArtifactId(),
                           model.getReleaseId().getVersion());
@@ -239,7 +239,7 @@ public class M2RepoServiceImpl implements M2RepoService,
     @Override
     public String getRepositoryURL(final String baseURL) {
         if (baseURL == null || baseURL.isEmpty()) {
-            return repository.getRepositoryURL(ArtifactRepositoryFactory.GLOBAL_M2_REPO_NAME);
+            return repository.getRepositoryURL(ArtifactRepositoryService.GLOBAL_M2_REPO_NAME);
         } else {
             if (baseURL.endsWith("/")) {
                 return baseURL + "maven2/";

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepositoryService.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepositoryService.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server.repositories;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Any;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+@ApplicationScoped
+public class ArtifactRepositoryService {
+
+    public static final String LOCAL_M2_REPO_NAME = "local-m2-repo";
+    public static final String GLOBAL_M2_REPO_NAME = "global-m2-repo";
+    public static final String WORKSPACE_M2_REPO_NAME = "workspace-m2-repo";
+    public static final String DISTRIBUTION_MANAGEMENT_REPO_NAME = "distribution-management-repo";
+    public static final String ORG_GUVNOR_M2REPO_DIR_PROPERTY = "org.guvnor.m2repo.dir";
+
+    private List<ArtifactRepository> repositories;
+
+    public ArtifactRepositoryService() {
+    }
+
+    @Inject
+    public ArtifactRepositoryService(@Repository @Any Instance<ArtifactRepository> artifactRepositoryInstances) {
+        this.repositories = new ArrayList<>();
+        for (ArtifactRepository artifactRepository : artifactRepositoryInstances) {
+            this.repositories.add(artifactRepository);
+        }
+    }
+
+    public List<? extends ArtifactRepository> getRepositories() {
+        return this.repositories.stream().filter(ArtifactRepository::isRepository).collect(Collectors.toList());
+    }
+
+    public List<? extends ArtifactRepository> getPomRepositories() {
+        return this.repositories.stream().filter(ArtifactRepository::isPomRepository).collect(Collectors.toList());
+    }
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/DistributionManagementArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/DistributionManagementArtifactRepository.java
@@ -105,7 +105,7 @@ public class DistributionManagementArtifactRepository implements ArtifactReposit
                        final Artifact... artifacts) {
         try {
 
-            MavenEmbedder embedder = MavenProjectLoader.newMavenEmbedder( false);
+            MavenEmbedder embedder = MavenProjectLoader.newMavenEmbedder(false);
             DistributionManagement distributionManagement = getDistributionManagement(pom,
                                                                                       embedder);
 
@@ -137,8 +137,8 @@ public class DistributionManagementArtifactRepository implements ArtifactReposit
                     remoteRequest.setRepository(getRemoteRepoFromDeployment(remoteRepository,
                                                                             embedder));
 
-                    Aether.getAether().getSystem().deploy( Aether.getAether().getSession(),
-                                                           remoteRequest);
+                    Aether.getAether().getSystem().deploy(Aether.getAether().getSession(),
+                                                          remoteRequest);
                 }
             }
         } catch (DeploymentException e) {

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/FileSystemArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/FileSystemArtifactRepository.java
@@ -19,7 +19,6 @@ package org.guvnor.m2repo.backend.server.repositories;
 
 import java.io.File;
 import java.net.MalformedURLException;
-import java.net.URI;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -70,7 +69,7 @@ public class FileSystemArtifactRepository implements ArtifactRepository {
         }
         this.repositoryDirectory = dir;
         this.repository = this.createRepository(dir);
-        Aether.getAether().getRepositories().add( this.getRepository());
+        Aether.getAether().getRepositories().add(this.getRepository());
     }
 
     @Override

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/LocalArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/LocalArtifactRepository.java
@@ -89,8 +89,8 @@ public class LocalArtifactRepository implements ArtifactRepository {
                 installRequest
                         .addArtifact(artifact);
             }
-            Aether.getAether().getSystem().install( Aether.getAether().getSession(),
-                                                    installRequest);
+            Aether.getAether().getSystem().install(Aether.getAether().getSession(),
+                                                   installRequest);
         } catch (InstallationException e) {
             throw new RuntimeException(e);
         }

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/NullArtifactRepository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/NullArtifactRepository.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server.repositories;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.aether.artifact.Artifact;
+import org.guvnor.common.services.project.model.GAV;
+
+public class NullArtifactRepository implements ArtifactRepository {
+
+    private static final String NULL_ARTIFACT_REPOSITORY_NAME = "null-m2-repo";
+
+    @Override
+    public String getName() {
+        return NULL_ARTIFACT_REPOSITORY_NAME;
+    }
+
+    @Override
+    public String getRootDir() {
+        return null;
+    }
+
+    @Override
+    public Collection<File> listFiles(List<String> wildcards) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Collection<Artifact> listArtifacts(List<String> wildcards) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public void deploy(String pom,
+                       Artifact... artifacts) {
+
+    }
+
+    @Override
+    public void delete(GAV gav) {
+
+    }
+
+    @Override
+    public boolean containsArtifact(GAV gav) {
+        return false;
+    }
+
+    @Override
+    public File getArtifactFileFromRepository(GAV gav) {
+        return null;
+    }
+
+    @Override
+    public boolean isRepository() {
+        return false;
+    }
+
+    @Override
+    public boolean isPomRepository() {
+        return false;
+    }
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/Repository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/repositories/Repository.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server.repositories;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, PARAMETER})
+public @interface Repository {
+
+}

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
@@ -25,7 +25,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.enterprise.inject.Instance;
 
 import org.appformer.maven.integration.Aether;
@@ -38,7 +37,9 @@ import org.eclipse.aether.installation.InstallationException;
 import org.eclipse.aether.repository.Authentication;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.guvnor.common.services.project.model.GAV;
-import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryFactory;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepository;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryProducer;
+import org.guvnor.m2repo.backend.server.repositories.ArtifactRepositoryService;
 import org.guvnor.m2repo.preferences.ArtifactRepositoryPreference;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -58,6 +59,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.uberfire.backend.server.cdi.workspace.WorkspaceNameResolver;
+import org.uberfire.mocks.MockInstanceImpl;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -125,9 +127,14 @@ public class GuvnorM2RepositoryTest {
         when(pref.isWorkspaceM2RepoDirEnabled()).thenReturn(false);
         WorkspaceNameResolver resolver = mock(WorkspaceNameResolver.class);
         when(resolver.getWorkspaceName()).thenReturn("global");
-        ArtifactRepositoryFactory factory = new ArtifactRepositoryFactory(pref,
-                                                                          resolver);
-        factory.initialize();
+        ArtifactRepositoryProducer producer = new ArtifactRepositoryProducer(pref,
+                                                                             resolver);
+        producer.initialize();
+        Instance<ArtifactRepository> repositories = new MockInstanceImpl<>(producer.produceLocalRepository(),
+                                                                           producer.produceGlobalRepository(),
+                                                                           producer.produceDistributionManagementRepository());
+        ArtifactRepositoryService factory = new ArtifactRepositoryService(repositories);
+
         repo = new GuvnorM2Repository(factory);
         repo.init();
 

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepositoryServiceTest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/repositories/ArtifactRepositoryServiceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.guvnor.m2repo.backend.server.repositories;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.uberfire.mocks.MockInstanceImpl;
+
+import static org.jgroups.util.Util.assertEquals;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ArtifactRepositoryServiceTest {
+
+    private ArtifactRepositoryService artifactRepositoryService;
+    private ArtifactRepository artifactRepository1;
+    private ArtifactRepository artifactRepository2;
+    private ArtifactRepository artifactRepository3;
+    private ArtifactRepository artifactRepository4;
+    private ArtifactRepository artifactRepository5;
+
+    @Before
+    public void setUp() {
+
+        artifactRepository1 = mock(ArtifactRepository.class);
+        artifactRepository2 = mock(ArtifactRepository.class);
+        artifactRepository3 = mock(ArtifactRepository.class);
+        artifactRepository4 = mock(ArtifactRepository.class);
+        artifactRepository5 = mock(ArtifactRepository.class);
+
+        when(artifactRepository1.isRepository()).thenReturn(true);
+        when(artifactRepository2.isRepository()).thenReturn(true);
+        when(artifactRepository3.isRepository()).thenReturn(true);
+        when(artifactRepository4.isRepository()).thenReturn(true);
+        when(artifactRepository5.isRepository()).thenReturn(false);
+
+        when(artifactRepository1.isPomRepository()).thenReturn(true);
+        when(artifactRepository2.isPomRepository()).thenReturn(true);
+        when(artifactRepository3.isPomRepository()).thenReturn(false);
+        when(artifactRepository4.isPomRepository()).thenReturn(false);
+        when(artifactRepository5.isPomRepository()).thenReturn(false);
+
+        MockInstanceImpl<ArtifactRepository> instance = new MockInstanceImpl<>(artifactRepository1,
+                                                                               artifactRepository2,
+                                                                               artifactRepository3,
+                                                                               artifactRepository4,
+                                                                               artifactRepository5);
+
+        this.artifactRepositoryService = new ArtifactRepositoryService(instance);
+    }
+
+    @Test
+    public void testDeploymentRepositories() {
+        List<? extends ArtifactRepository> repositories = this.artifactRepositoryService.getRepositories();
+        assertEquals(4,
+                     repositories.size());
+        assertTrue(Arrays.asList(this.artifactRepository1,
+                                 this.artifactRepository2,
+                                 this.artifactRepository3,
+                                 this.artifactRepository4).containsAll(repositories));
+        assertFalse(repositories.contains(this.artifactRepository5));
+    }
+
+    @Test
+    public void testPomRepositories() {
+        List<? extends ArtifactRepository> repositories = this.artifactRepositoryService.getPomRepositories();
+        assertEquals(2,
+                     repositories.size());
+        assertTrue(Arrays.asList(this.artifactRepository1,
+                                 this.artifactRepository2).containsAll(repositories));
+        assertFalse(repositories.contains(this.artifactRepository3));
+        assertFalse(repositories.contains(this.artifactRepository4));
+        assertFalse(repositories.contains(this.artifactRepository5));
+    }
+}


### PR DESCRIPTION
This is the new Artifact Repositories infrastructure. It replaces the previous one with some injectable repositories.

There are some important components:

**ArtifactRepository**: This is the interface that every repository should implement. As you can see not all the repositories have to implement all the method, for instance the DistributionManagement repository is just an abstraction for the parameters that are in _pom.xm_

**@Repository**: Is the qualifier it should have every repository. 

**ArtifactRepositoryProducer**: Produces all the repositories. You can add more repositories there. It uses ArtifactRepositoryPreferences to know if the repository is enabled and to configure repositories paths.

**ArtifactRepositoryService**: Concentrates all repositories in one place. Automatically find all @Repository entities and inject them there. It also contain some repository names.

