### PR TITLE
AF-547: VFS commit batch broken

### DIFF
--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/MetadataServiceImpl.java
@@ -29,6 +29,7 @@ import org.guvnor.common.services.backend.exceptions.ExceptionUtilities;
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionAttributes;
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionAttributesUtil;
 import org.guvnor.common.services.backend.metadata.attribute.DiscussionView;
+import org.guvnor.common.services.backend.metadata.attribute.GeneratedAttributesUtil;
 import org.guvnor.common.services.backend.metadata.attribute.GeneratedAttributesView;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaAttributes;
 import org.guvnor.common.services.backend.metadata.attribute.OtherMetaAttributesUtil;
@@ -132,6 +133,7 @@ public class MetadataServiceImpl
             attrs = DublinCoreAttributesUtil.cleanup(attrs);
             attrs = DiscussionAttributesUtil.cleanup(attrs);
             attrs = OtherMetaAttributesUtil.cleanup(attrs);
+            attrs = GeneratedAttributesUtil.cleanup(attrs);
 
             attrs.putAll(DiscussionAttributesUtil.toMap(
                     new DiscussionAttributes() {
@@ -371,8 +373,10 @@ public class MetadataServiceImpl
                     },
                     "*"));
 
-            attrs.put(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME,
-                      metadata.isGenerated());
+            if (metadata.isGenerated()) {
+                attrs.put(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME,
+                          true);
+            }
 
             return attrs;
         } catch (Exception e) {

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesUtil.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesUtil.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.backend.metadata.attribute;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class GeneratedAttributesUtil {
+
+    private GeneratedAttributesUtil() {
+    }
+
+    /**
+     * Remove attribute mappings specific to GeneratedAttributesView from the
+     * map of all available file attributes.
+     */
+    public static Map<String, Object> cleanup(final Map<String, Object> _attrs) {
+        final Map<String, Object> attrs = new HashMap<>(_attrs);
+
+        attrs.replace(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME, null);
+
+        return attrs;
+    }
+}

--- a/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesView.java
+++ b/guvnor-services/guvnor-services-backend/src/main/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesView.java
@@ -98,7 +98,13 @@ public class GeneratedAttributesView extends AbstractBasicFileAttributeView<Abst
     private boolean extractGenerated() {
         final Map<String, Object> content = path.getAttrStorage().getContent();
 
-        return Boolean.parseBoolean(String.valueOf(content.get(GENERATED_ATTRIBUTE_NAME)));
+        final Object generatedFileAttribute = content.get(GENERATED_ATTRIBUTE_NAME);
+
+        if (generatedFileAttribute instanceof Boolean) {
+            return (Boolean) generatedFileAttribute;
+        }
+
+        return false;
     }
 
     @Override

--- a/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesUtilTest.java
+++ b/guvnor-services/guvnor-services-backend/src/test/java/org/guvnor/common/services/backend/metadata/attribute/GeneratedAttributesUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.guvnor.common.services.backend.metadata.attribute;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GeneratedAttributesUtilTest {
+
+    @Test
+    public void cleanup() {
+        Map<String, Object> originalAttributeMap = new HashMap<String, Object>() {{
+            put(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME,
+                true);
+            put("customAttribute",
+                "value");
+        }};
+
+        Map<String, Object> result = GeneratedAttributesUtil.cleanup(originalAttributeMap);
+
+        assertNull(result.get(GeneratedAttributesView.GENERATED_ATTRIBUTE_NAME));
+        assertNotNull(result.get("customAttribute"));
+    }
+}


### PR DESCRIPTION
Add 'generated' metadata attribute only for files that have actually been generated - this avoids generating dot files for non-generated files (which will likely be > 90 % cases).

Part of:
https://github.com/kiegroup/guvnor/pull/473
https://github.com/AppFormer/uberfire/pull/764