### PR TITLE
JBPM-6337: Windows don't remove last File separator resolving reposit…

### DIFF
--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/main/java/org/guvnor/m2repo/backend/server/GuvnorM2Repository.java
@@ -89,8 +89,8 @@ public class GuvnorM2Repository {
     }
 
     public String getM2RepositoryDir(String repositoryName) {
-        return this.getM2RepositoryRootDir(repositoryName).replaceAll("/$",
-                                                                      "");
+        String rootDir = this.getM2RepositoryRootDir(repositoryName);
+        return rootDir.substring(0,rootDir.lastIndexOf(File.separator));
     }
 
     public String getM2RepositoryRootDir(String repositoryName) {

--- a/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
+++ b/guvnor-m2repo-editor/guvnor-m2repo-editor-backend/src/test/java/org/guvnor/m2repo/backend/server/GuvnorM2RepositoryTest.java
@@ -290,4 +290,13 @@ public class GuvnorM2RepositoryTest {
         exception.expect(RuntimeException.class);
         repo.getPomText("dir/name.foo");
     }
+
+    @Test
+    public void testGetM2RepositoryDirRemovesLastFileSeparator() {
+        String rootDir = repo.getM2RepositoryRootDir(ArtifactRepositoryService.GLOBAL_M2_REPO_NAME);
+        assertTrue(rootDir.endsWith(File.separator));
+
+        String repodir = repo.getM2RepositoryDir(ArtifactRepositoryService.GLOBAL_M2_REPO_NAME);
+        assertFalse(repodir.endsWith(File.separator));
+    }
 }


### PR DESCRIPTION
…ory dir causing bad gav resolution
Changed the way that getM2RepositoryDiv removes the last File.separator to make it work properly on windows OS